### PR TITLE
Adding an all function to the Index class to list all indexes

### DIFF
--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -540,6 +540,10 @@ module Algolia
       aggregated_answer
     end
 
+    def Index.all
+      Algolia.client.get(Protocol.indexes_uri)
+    end
+
     private
     def check_array(objs)
       raise ArgumentError.new("argument must be an array of objects") if !objs.is_a?(Array)


### PR DESCRIPTION
This is identical to Algolia.list_indexes but I am adding it since this seems like a more appropriate place and is where I imagine most devs will look for it first. This could also be aliased to Algolia::Index.list_all or something similar - your call.
