### PR TITLE
Using Digest to remove "Digest::Digest is deprecated; Use Digest" warning

### DIFF
--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -179,7 +179,7 @@ module Algolia
       tag_filters = tag_filters.map { |t| t.is_a?(Array) ? "(#{t.join(',')})" : t }.join(',')
     end
     raise ArgumentError.new('Attribute "tag_filters" must be a list of tags') if !tag_filters.is_a?(String)
-    OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha256'), private_api_key, "#{tag_filters}#{user_token.to_s}")
+    OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), private_api_key, "#{tag_filters}#{user_token.to_s}")
   end
 
   #


### PR DESCRIPTION
Driving us nuts when running our unit tests :-)
