### PR TITLE
Avoid unnecessarily setting the timeout on the HTTPClient

### DIFF
--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -104,8 +104,10 @@ module Algolia
         end
         return JSON.parse(response.content)
       ensure
-        session.send_timeout = original_send_timeout
-        session.receive_timeout = original_receive_timeout
+        if timeout
+          session.send_timeout = original_send_timeout unless timeout == original_send_timeout
+          session.receive_timeout = original_receive_timeout unless timeout == original_receive_timeout
+        end
       end
     end
 


### PR DESCRIPTION
Any time the timeout setters (e.g. `send_timeout=`) are called on an
`HTTPClient` instance, the [session pool is
cleared](https://github.com/nahi/httpclient/blob/master/lib/httpclient.rb#L302).
This means that every request was inadvertently opening a new connection.

This patch adds some guards to ensure that we only reset the `send_timeout` and
`receive_timeout` in the `ensure` block at the end of the request if doing so
would have an effect. This is only a partial solution—in the case where the
`search_timeout` configuration is used in the client, we'll still be setting
the `timeout`s on the client every request, and thus losing the keepalive.

I'll leave it up to y'all to figure out the best way to fix the problem in the
`search_timeout` case—my hunch is that holding a separate `search_session` is
probably the move, so as to avoid ever having to modify timeouts on a
per-request basis.
