### PR TITLE
Webmock Helper: Don't break other test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ index.set_settings({"customRanking" => ["desc(followers)"]})
 
 You can also configure the list of attributes you want to index by order of importance (first = most important):
 ```ruby
-index.set_settings({"attributesToIndex" => ["lastname", "firstname", "company", 
+index.set_settings({"attributesToIndex" => ["lastname", "firstname", "company",
                                             "email", "city", "address"]})
 ```
 
@@ -197,7 +197,7 @@ Objects are schema less, you don't need any configuration to start indexing. The
 Example with automatic `objectID` assignement:
 
 ```ruby
-res = index.add_object({"firstname" => "Jimmie", 
+res = index.add_object({"firstname" => "Jimmie",
                         "lastname" => "Barninger"})
 puts "ObjectID=" + res["objectID"]
 ```
@@ -205,7 +205,7 @@ puts "ObjectID=" + res["objectID"]
 Example with manual `objectID` assignement:
 
 ```ruby
-res = index.add_object({"firstname" => "Jimmie", 
+res = index.add_object({"firstname" => "Jimmie",
                         "lastname" => "Barninger"}, "myID")
 puts "ObjectID=" + res["objectID"]
 ```
@@ -222,7 +222,7 @@ You have three options to update an existing object:
 Example to replace all the content of an existing object:
 
 ```ruby
-index.save_object({"firstname" => "Jimmie", 
+index.save_object({"firstname" => "Jimmie",
                    "lastname" => "Barninger",
                    "city" => "New York",
                    "objectID" => "myID"})
@@ -231,7 +231,7 @@ index.save_object({"firstname" => "Jimmie",
 Example to update only the city attribute of an existing object:
 
 ```ruby
-index.partial_update_object({"city" => "San Francisco", 
+index.partial_update_object({"city" => "San Francisco",
                              "objectID" => "myID"})
 ```
 
@@ -339,7 +339,7 @@ You can use the following optional arguments:
   * **none**: if none of the query terms were found.
  * **attributesToSnippet**: a string that contains the list of attributes to snippet alongside the number of words to return (syntax is `attributeName:nbWords`). Attributes are separated by a comma (Example: `attributesToSnippet=name:10,content:10`). <br/>You can also use a string array encoding (Example: `attributesToSnippet: ["name:10","content:10"]`). By default no snippet is computed.
  * **getRankingInfo**: if set to 1, the result hits will contain ranking information in **_rankingInfo** attribute.
- 
+
 
 #### Numeric search parameters
  * **numericFilters**: a string that contains the list of numeric filters you want to apply separated by a comma. The syntax of one filter is `attributeName` followed by `operand` followed by `value`. Supported operands are `<`, `<=`, `=`, `>` and `>=`.
@@ -570,7 +570,7 @@ All write operations return a `taskID` when the job is securely stored on our in
 
 For example, to wait for indexing of a new object:
 ```ruby
-res = index.add_object!({"firstname" => "Jimmie", 
+res = index.add_object!({"firstname" => "Jimmie",
                          "lastname" => "Barninger"})
 ```
 
@@ -589,18 +589,18 @@ We expose three methods to perform batch:
 
 Example using automatic `objectID` assignement:
 ```ruby
-res = index.add_objects([{"firstname" => "Jimmie", 
+res = index.add_objects([{"firstname" => "Jimmie",
                           "lastname" => "Barninger"},
-                         {"firstname" => "Warren", 
+                         {"firstname" => "Warren",
                           "lastname" => "Speach"}])
 ```
 
 Example with user defined `objectID` (add or update):
 ```ruby
-res = index.save_objects([{"firstname" => "Jimmie", 
+res = index.save_objects([{"firstname" => "Jimmie",
                           "lastname" => "Barninger",
                            "objectID" => "myID1"},
-                          {"firstname" => "Warren", 
+                          {"firstname" => "Warren",
                           "lastname" => "Speach",
                            "objectID" => "myID2"}])
 ```
@@ -612,9 +612,9 @@ res = index.delete_objects(["myID1", "myID2"])
 
 Example that update only the `firstname` attribute:
 ```ruby
-res = index.partial_update_objects([{"firstname" => "Jimmie", 
+res = index.partial_update_objects([{"firstname" => "Jimmie",
                                      "objectID" => "SFO"},
-                                    {"firstname" => "Warren", 
+                                    {"firstname" => "Warren",
                                      "objectID" => "myID2"}])
 ```
 
@@ -835,6 +835,7 @@ describe 'With a mocked client' do
 
   before(:each) do
     WebMock.enable!
+    Algolia.load_webmocks!
   end
 
   it "shouldn't perform any API calls here" do
@@ -852,5 +853,4 @@ describe 'With a mocked client' do
 end
 ```
 
-
-
+You can also require `'algolia/webmock_rspec'` which runs `load_webmocks!` in a before filter for you.

--- a/algoliasearch.gemspec
+++ b/algoliasearch.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
     "lib/algolia/protocol.rb",
     "lib/algolia/version.rb",
     "lib/algolia/webmock.rb",
+    "lib/algolia/webmock_rspec.rb",
     "lib/algoliasearch.rb",
     "resources/ca-bundle.crt",
     "spec/client_spec.rb",
@@ -64,4 +65,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<json>, [">= 1.5.1"])
   end
 end
-

--- a/lib/algolia/webmock.rb
+++ b/lib/algolia/webmock.rb
@@ -46,8 +46,8 @@ ALGOLIA_WEBMOCKS = {
   [:delete, %r{/1/keys/[^/]+}] => '{ }',
 }
 
-RSpec.configure do |config|
-  config.before :each do
+module Algolia
+  def self.load_webmocks!
     WebMock.stub_request(:any, /.*\.algolia\.(io|net)/).to_return do |request|
       match = ALGOLIA_WEBMOCKS.find do |pattern, retval|
         request.method == pattern[0] && pattern[1].match(request.uri.path)

--- a/lib/algolia/webmock.rb
+++ b/lib/algolia/webmock.rb
@@ -5,44 +5,60 @@ rescue LoadError
   exit 1
 end
 
-# disable by default
-WebMock.disable!
+ALGOLIA_WEBMOCKS = {
+  # list indexes
+  [:get, %r{/1/indexes/}] => '{ "items": [] }',
+  # query index
+  [:get, %r{/1/indexes/[^/]+}] => '{}',
+  [:post, %r{/1/indexes/[^/]+/query}] => '{}',
+  # delete index
+  [:delete, %r{/1/indexes/[^/]+}] => '{ "taskID": 42 }',
+  # clear index
+  [:post, %r{/1/indexes/[^/]+/clear}] => '{ "taskID": 42 }',
+  # add object
+  [:post, %r{/1/indexes/[^/]+}] => '{ "taskID": 42 }',
+  # save object
+  [:put, %r{/1/indexes/[^/]+/[^/]+}] => '{ "taskID": 42 }',
+  # partial update
+  [:put, %r{/1/indexes/[^/]+/[^/]+/partial}] => '{ "taskID": 42 }',
+  # get object
+  [:get, %r{/1/indexes/[^/]+/[^/]+}] => '{}',
+  # delete object
+  [:delete, %r{/1/indexes/[^/]+/[^/]+}] => '{ "taskID": 42 }',
+  # batch
+  [:post, %r{/1/indexes/[^/]+/batch}] => '{ "taskID": 42 }',
+  # settings
+  [:get, %r{/1/indexes/[^/]+/settings}] => '{}',
+  [:put, %r{/1/indexes/[^/]+/settings}] => '{ "taskID": 42 }',
+  # browse
+  [:get, %r{/1/indexes/[^/]+/browse}] => '{}',
+  # operations
+  [:post, %r{/1/indexes/[^/]+/operation}] => '{ "taskID": 42 }',
+  # tasks
+  [:get, %r{/1/indexes/[^/]+/task/[^/]+}] => '{ "status": "published" }',
+  # index keys
+  [:post, %r{/1/indexes/[^/]+/keys}] => '{ }',
+  [:get, %r{/1/indexes/[^/]+/keys}] => '{ "keys": [] }',
+  # global keys
+  [:post, %r{/1/keys}] => '{ }',
+  [:get, %r{/1/keys}] => '{ "keys": [] }',
+  [:get, %r{/1/keys/[^/]+}] => '{ }',
+  [:delete, %r{/1/keys/[^/]+}] => '{ }',
+}
 
-# list indexes
-WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes/).to_return(:body => '{ "items": [] }')
-# query index
-WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+/).to_return(:body => '{}')
-WebMock.stub_request(:post, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/query/).to_return(:body => '{}')
-# delete index
-WebMock.stub_request(:delete, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "taskID": 42 }')
-# clear index
-WebMock.stub_request(:post, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/clear/).to_return(:body => '{ "taskID": 42 }')
-# add object
-WebMock.stub_request(:post, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "taskID": 42 }')
-# save object
-WebMock.stub_request(:put, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/[^\/]+/).to_return(:body => '{ "taskID": 42 }')
-# partial update
-WebMock.stub_request(:put, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/[^\/]+\/partial/).to_return(:body => '{ "taskID": 42 }')
-# get object
-WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/[^\/]+/).to_return(:body => '{}')
-# delete object
-WebMock.stub_request(:delete, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/[^\/]+/).to_return(:body => '{ "taskID": 42 }')
-# batch
-WebMock.stub_request(:post, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/batch/).to_return(:body => '{ "taskID": 42 }')
-# settings
-WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/settings/).to_return(:body => '{}')
-WebMock.stub_request(:put, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/settings/).to_return(:body => '{ "taskID": 42 }')
-# browse
-WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/browse/).to_return(:body => '{}')
-# operations
-WebMock.stub_request(:post, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/operation/).to_return(:body => '{ "taskID": 42 }')
-# tasks
-WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/task\/[^\/]+/).to_return(:body => '{ "status": "published" }')
-# index keys
-WebMock.stub_request(:post, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/keys/).to_return(:body => '{ }')
-WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/keys/).to_return(:body => '{ "keys": [] }')
-# global keys
-WebMock.stub_request(:post, /.*\.algolia\.(io|net)\/1\/keys/).to_return(:body => '{ }')
-WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/keys/).to_return(:body => '{ "keys": [] }')
-WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/keys\/[^\/]+/).to_return(:body => '{ }')
-WebMock.stub_request(:delete, /.*\.algolia\.(io|net)\/1\/keys\/[^\/]+/).to_return(:body => '{ }')
+RSpec.configure do |config|
+  config.before :each do
+    WebMock.stub_request(:any, /.*\.algolia\.(io|net)/).to_return do |request|
+      match = ALGOLIA_WEBMOCKS.find do |pattern, retval|
+        request.method == pattern[0] && pattern[1].match(request.uri.path)
+      end
+
+      if match
+        { body: match[1] }
+      else
+        raise format('Un-mocked Algolia request in WebMock mode: %s %s',
+                     request.method.upcase, request.uri)
+      end
+    end
+  end
+end

--- a/lib/algolia/webmock_rspec.rb
+++ b/lib/algolia/webmock_rspec.rb
@@ -1,0 +1,7 @@
+require 'algolia/webmock'
+
+RSpec.configure do |config|
+  config.before :each do
+    Algolia.load_webmocks!
+  end
+end

--- a/spec/mock_spec.rb
+++ b/spec/mock_spec.rb
@@ -9,6 +9,7 @@ describe 'With a mocked client' do
 
   before(:each) do
     WebMock.enable!
+    Algola.load_webmocks!
     Thread.current[:algolia_hosts] = nil # reset session objects
   end
 

--- a/spec/mock_spec.rb
+++ b/spec/mock_spec.rb
@@ -1,5 +1,8 @@
 require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
 
+require 'webmock'
+WebMock.disable!
+
 require 'algolia/webmock'
 
 describe 'With a mocked client' do


### PR DESCRIPTION
## Scope

This changes the mocks in this gem to be less likely to break other project test suites that also use Webmock, by applying the mocks in a rspec before filter instead of directly when you include the file.

In addition this change makes it easier to add newly mocked API requests, and rejects requests to algolia.io that are not mocked.

We've been using this change happily at Product Hunt for the last few months, sorry that it took so long to propose it upstream :)