### PR TITLE
Fix broken request stub

### DIFF
--- a/lib/algolia/webmock.rb
+++ b/lib/algolia/webmock.rb
@@ -11,7 +11,7 @@ WebMock.disable!
 # list indexes
 WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes/).to_return(:body => '{ "items": [] }')
 # query index
-WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+/).to_return(:body => '{}')
+WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "hits": [ { "objectID": 42 } ], "page": 1, "hitsPerPage": 1 }')
 WebMock.stub_request(:post, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+\/query/).to_return(:body => '{}')
 # delete index
 WebMock.stub_request(:delete, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "taskID": 42 }')

--- a/spec/mock_spec.rb
+++ b/spec/mock_spec.rb
@@ -12,7 +12,7 @@ describe 'With a mocked client' do
   it "should add a simple object" do
     index = Algolia::Index.new("friends")
     index.add_object!({ :name => "John Doe", :email => "john@doe.org" })
-    index.search('').should == {} # mocked
+    index.search('').should == { "hits" => [ { "objectID" => 42 } ], "page" => 1, "hitsPerPage" => 1 } # mocked
     index.list_user_keys
     index.browse
     index.clear


### PR DESCRIPTION
For some reason this stub:
 ```ruby 
WebMock.stub_request(:get, /.*\.algolia\.(io|net)\/1\/indexes\/[^\/]+/).to_return(:body => '{}')
``` 

caused the following error:

```console
NoMethodError:
       undefined method `map' for nil:NilClass
     # ./.bundle/ruby/2.2.0/gems/algoliasearch-rails-1.11.12/lib/algoliasearch-rails.rb:412:in `algolia_search'
```

in this spec:

```ruby
require "rails_helper"

describe "With a mocked client" do
  it "shouldn't perform any API calls here" do
    create(:group) 
    expect(Group.search("")).to be_empty
  end
end
```

The error was thrown because `algoliasearch-rails` expects having some keys like `hits` and `page` in the JSON response and fails if response doesn't have them.

I'm not sure if we should have such verbose stub in `algoliasearch-client-ruby`, probably it is better to add empty response handling to `algoliasearch-rails`, but this PR can work as a short-term fix. What do you guys think?