### PR TITLE
Cache Bundler dependencies on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ rvm:
 - 2.3.0
 - jruby
 - rbx-2
-install:
-- bundle install
+cache: bundler
 env:
   global:
   - secure: OFKp0J81VrKXfpQZWkwSfsG/knN4tr45yDAGekFy4FKcA6Ra6EqDUzcY1MVrkKq9YRUgLJRfjgqF3Ei0cm2qMo1dy5XUG/fY8upTVdQK2Nm1qfbjnh70+vnYpHidHg9pEI8QROwsM7n19QoT16j1af4UinGFE/HBiJpuXcABuLw=


### PR DESCRIPTION
Hi,

I'm a Customer Support Specialist at Travis CI.

Here's a small change (following a discussion with @ElPicador) that should help you get faster builds. Here are some explanation on what it does:

1) Removing the `install:` section will make Travis CI call `bundle install` under the hood. Dependencies will be installed in a default directory compatible with [our caching feature](https://docs.travis-ci.com/user/caching/).

2) `cache: bundler` tells Travis CI to cache your Bundler dependencies. Hence, they will be zipped at the end of a build and uploaded to S3. Afterward, they will be downloaded and extracted at the start of a new build. The cache archive is updated anytime your dependencies change.

Hope this helps. Don't hesitate to reach out at contact [at] travis-ci [dot] com if you have follow-up questions on this.