### PR TITLE
Update fallback host logic to reflect comment

### DIFF
--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -399,7 +399,7 @@ module Algolia
       hosts = Thread.current[thread_hosts_key]
       thread_index_key = read ? "algolia_search_host_index_#{application_id}" : "algolia_host_index_#{application_id}"
       current_host = Thread.current[thread_index_key].to_i # `to_i` to ensure first call is 0
-      if current_host != 0 && hosts[current_host][:last_call].to_i < Time.now.to_i - 60
+      if current_host != 0 && hosts[0][:last_call].to_i > Time.now.to_i - 60
         # the current_host is not the first one and we've been using it for less than a minute; continue doing so
         first = hosts[current_host]
         [first] + hosts.reject { |h| h[:index] == 0 || h == first } + hosts.select { |h| h[:index] == 0 }

--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -399,7 +399,7 @@ module Algolia
       hosts = Thread.current[thread_hosts_key]
       thread_index_key = read ? "algolia_search_host_index_#{application_id}" : "algolia_host_index_#{application_id}"
       current_host = Thread.current[thread_index_key].to_i # `to_i` to ensure first call is 0
-      if current_host != 0 && hosts[0][:last_call].to_i > Time.now.to_i - 60
+      if current_host != 0 && hosts[current_host][:last_call].to_i > Time.now.to_i - 60
         # the current_host is not the first one and we've been using it for less than a minute; continue doing so
         first = hosts[current_host]
         [first] + hosts.reject { |h| h[:index] == 0 || h == first } + hosts.select { |h| h[:index] == 0 }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -979,7 +979,7 @@ describe 'Client' do
   end
 
   context 'DNS timeout' do
-    before(:all) do
+    before(:each) do
       app_id = ENV['ALGOLIA_APPLICATION_ID']
       Thread.current["algolia_hosts_#{app_id}"] = nil
       Thread.current["algolia_search_hosts_#{app_id}"] = nil
@@ -1008,7 +1008,7 @@ describe 'Client' do
       expect(start_time.to_i + 5).to be <= Time.now.to_i + 1
       start_time = Time.now
       @client.list_indexes # re-use the 2nd one
-      expect(start_time.to_i).to be <= Time.now.to_i + 1
+      expect(start_time.to_i).to be >= Time.now.to_i - 1
     end
   end
 


### PR DESCRIPTION
The behavior exhibited by the if statement does not reflect the
description in the comment below it: instead of reusing a fallback host if
it's been in use for less than a minute, it actually reuses the fallback
host only if it was last used more than a minute ago.

This was not caught by the test that was added with it, because the test
logic is faulty as well: the only way it could fail is if the value of
`Time.now` actually decreased over time.

This updates the test to assert that the second call completes in less
than a second, rather than timing out, and updates the logic to continue
to use the current (not first) host if the first host was last called
less than a minute ago.

Finally, the DNS timeout test context is modified to reset the client
and thread local variables before each test, rather than before all of
them; otherwise the timeout in the first test case causes the first
check in the second test case to fail (since the client has already
fallen back to the second host)