### PR TITLE
Update httpclient dependency

### DIFF
--- a/algoliasearch.gemspec
+++ b/algoliasearch.gemspec
@@ -50,17 +50,17 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httpclient>, ["~> 2.8.2.4"])
+      s.add_runtime_dependency(%q<httpclient>, ["~> 2.8.3"])
       s.add_runtime_dependency(%q<json>, [">= 1.5.1"])
       s.add_development_dependency "travis"
       s.add_development_dependency "rake"
       s.add_development_dependency "rdoc"
     else
-      s.add_dependency(%q<httpclient>, ["~> 2.8.2.4"])
+      s.add_dependency(%q<httpclient>, ["~> 2.8.3"])
       s.add_dependency(%q<json>, [">= 1.5.1"])
     end
   else
-    s.add_dependency(%q<httpclient>, ["~> 2.8.2.4"])
+    s.add_dependency(%q<httpclient>, ["~> 2.8.3"])
     s.add_dependency(%q<json>, [">= 1.5.1"])
   end
 end


### PR DESCRIPTION
The current dependency on httpclient, `"~> 2.8.2.4"` prevents upgrades to `2.8.3`, the latest version of this gem.  A previous version of this dependency was `"~>2.8.2"`, which allowed the 2.8.3 upgrade.  Revert to a less-specific dependency to allow for upgrades.

Please let me know if there's more information I can provide!  Thank you for a fantastic tool!