### PR TITLE
chore(naming): rename user_key methods to api_keys

### DIFF
--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -198,12 +198,12 @@ module Algolia
     end
 
     # List all existing user keys with their associated ACLs
-    def list_user_keys
+    def list_api_keys
       get(Protocol.keys_uri, :read)
     end
 
     # Get ACL of a user key
-    def get_user_key(key)
+    def get_api_key(key)
       get(Protocol.key_uri(key), :read)
     end
 
@@ -234,7 +234,7 @@ module Algolia
     #  @param maxHitsPerQuery  the maximum number of hits this API key can retrieve in one call (0 means unlimited)
     #  @param indexes the optional list of targeted indexes
     #
-    def add_user_key(obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0, indexes = nil)
+    def add_api_key(obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0, indexes = nil)
       if obj.instance_of? Array
         params = {
           :acl => obj
@@ -282,7 +282,7 @@ module Algolia
     #  @param maxHitsPerQuery  the maximum number of hits this API key can retrieve in one call (0 means unlimited)
     #  @param indexes the optional list of targeted indexes
     #
-    def update_user_key(key, obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0, indexes = nil)
+    def update_api_key(key, obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0, indexes = nil)
       if obj.instance_of? Array
         params = {
           :acl => obj
@@ -303,9 +303,9 @@ module Algolia
       put(Protocol.key_uri(key), params.to_json)
     end
 
-
+   
     # Delete an existing user key
-    def delete_user_key(key)
+    def delete_api_key(key)
       delete(Protocol.key_uri(key))
     end
 
@@ -430,6 +430,12 @@ module Algolia
       return JSON.parse(response.content)
     end
 
+    # Deprecated
+    alias_method :list_user_keys, :list_api_keys
+    alias_method :get_user_key, :get_api_key
+    alias_method :add_user_key, :add_api_key
+    alias_method :update_user_key, :update_api_key
+    alias_method :delete_user_key, :delete_api_key
   end
 
   # Module methods
@@ -588,11 +594,21 @@ module Algolia
   end
 
   # List all existing user keys with their associated ACLs
+  def Algolia.list_api_keys
+    Algolia.client.list_api_keys
+  end
+
+  # Deprecated
   def Algolia.list_user_keys
-    Algolia.client.list_user_keys
+    Algolia.client.list_api_keys
   end
 
   # Get ACL of a user key
+  def Algolia.get_api_key(key)
+    Algolia.client.get_api_key(key)
+  end
+
+  # Deprecated
   def Algolia.get_user_key(key)
     Algolia.client.get_user_key(key)
   end
@@ -624,8 +640,13 @@ module Algolia
   #  @param maxHitsPerQuery  the maximum number of hits this API key can retrieve in one call (0 means unlimited)
   #  @param indexes the optional list of targeted indexes
   #
+  def Algolia.add_api_key(obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0, indexes = nil)
+    Algolia.client.add_api_key(obj, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes)
+  end
+
+  # Deprecated
   def Algolia.add_user_key(obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0, indexes = nil)
-    Algolia.client.add_user_key(obj, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes)
+    Algolia.client.add_api_key(obj, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes)
   end
 
   #
@@ -655,13 +676,23 @@ module Algolia
   #  @param maxHitsPerQuery  the maximum number of hits this API key can retrieve in one call (0 means unlimited)
   #  @param indexes the optional list of targeted indexes
   #
+  def Algolia.update_api_key(key, obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0, indexes = nil)
+    Algolia.client.update_api_key(key, obj, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes)
+  end
+
+  # Deprecated
   def Algolia.update_user_key(key, obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0, indexes = nil)
-    Algolia.client.update_user_key(key, obj, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes)
+    Algolia.client.update_api_key(key, obj, validity, maxQueriesPerIPPerHour, maxHitsPerQuery, indexes)
   end
 
   # Delete an existing user key
+  def Algolia.delete_api_key(key)
+    Algolia.client.delete_api_key(key)
+  end
+
+  # Deprecated
   def Algolia.delete_user_key(key)
-      Algolia.client.delete_user_key(key)
+    Algolia.client.delete_api_key(key)
   end
 
   # Send a batch request targeting multiple indices

--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -446,12 +446,12 @@ module Algolia
     end
 
     # List all existing user keys with their associated ACLs
-    def list_user_keys
+    def list_api_keys
       client.get(Protocol.index_keys_uri(name), :read)
     end
 
     # Get ACL of a user key
-    def get_user_key(key)
+    def get_api_key(key)
       client.get(Protocol.index_key_uri(name, key), :read)
     end
 
@@ -480,7 +480,7 @@ module Algolia
     #  @param maxQueriesPerIPPerHour the maximum number of API calls allowed from an IP address per hour (0 means unlimited)
     #  @param maxHitsPerQuery  the maximum number of hits this API key can retrieve in one call (0 means unlimited)
     #
-    def add_user_key(obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0)
+    def add_api_key(obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0)
       if obj.instance_of? Array
         params = {
           :acl => obj
@@ -525,7 +525,7 @@ module Algolia
     #  @param maxQueriesPerIPPerHour the maximum number of API calls allowed from an IP address per hour (0 means unlimited)
     #  @param maxHitsPerQuery  the maximum number of hits this API key can retrieve in one call (0 means unlimited)
     #
-    def update_user_key(key, obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0)
+    def update_api_key(key, obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0)
       if obj.instance_of? Array
         params = {
           :acl => obj
@@ -547,7 +547,7 @@ module Algolia
 
 
     # Delete an existing user key
-    def delete_user_key(key)
+    def delete_api_key(key)
       client.delete(Protocol.index_key_uri(name, key))
     end
 
@@ -770,6 +770,13 @@ module Algolia
       wait_task(res["taskID"])
       return res
     end
+
+    # Deprecated
+    alias_method :get_user_key, :get_api_key
+    alias_method :list_user_keys, :list_api_keys
+    alias_method :add_user_key, :add_api_key
+    alias_method :update_user_key, :update_api_key
+    alias_method :delete_user_key, :delete_api_key
 
     private
     def check_array(objs)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -400,7 +400,7 @@ describe 'Client' do
   def wait_key(index, key, &block)
     1.upto(60) do # do not wait too long
       begin
-        k = index.get_user_key(key)
+        k = index.get_api_key(key)
         if block_given?
           return if yield k
           # not found
@@ -418,7 +418,7 @@ describe 'Client' do
   def wait_key_missing(index, key)
     1.upto(60) do # do not wait too long
       begin
-        k = index.get_user_key(key)
+        k = index.get_api_key(key)
         sleep 1
       rescue
         # not found
@@ -430,7 +430,7 @@ describe 'Client' do
   def wait_global_key(key, &block)
     1.upto(60) do # do not wait too long
       begin
-        k = Algolia.get_user_key(key)
+        k = Algolia.get_api_key(key)
         if block_given?
           return if yield k
           # not found
@@ -448,7 +448,7 @@ describe 'Client' do
   def wait_global_key_missing(key)
     1.upto(60) do # do not wait too long
       begin
-        k = Algolia.get_user_key(key)
+        k = Algolia.get_api_key(key)
         sleep 1
       rescue
         # not found
@@ -459,46 +459,46 @@ describe 'Client' do
 
   it "should test index keys" do
     @index.set_settings!({}) # ensure the index exists
-    resIndex = @index.list_user_keys
-    newIndexKey = @index.add_user_key(['search'])
+    resIndex = @index.list_api_keys
+    newIndexKey = @index.add_api_key(['search'])
     newIndexKey['key'].should_not eq("")
     wait_key(@index, newIndexKey['key'])
-    resIndexAfter = @index.list_user_keys
+    resIndexAfter = @index.list_api_keys
     is_include(resIndex['keys'], 'value', newIndexKey['key']).should eq(false)
     is_include(resIndexAfter['keys'], 'value', newIndexKey['key']).should eq(true)
-    indexKey = @index.get_user_key(newIndexKey['key'])
+    indexKey = @index.get_api_key(newIndexKey['key'])
     indexKey['acl'][0].should eq('search')
-    @index.update_user_key(newIndexKey['key'], ['addObject'])
+    @index.update_api_key(newIndexKey['key'], ['addObject'])
     wait_key(@index, newIndexKey['key']) do |key|
       key['acl'] == ['addObject']
     end
-    indexKey = @index.get_user_key(newIndexKey['key'])
+    indexKey = @index.get_api_key(newIndexKey['key'])
     indexKey['acl'][0].should eq('addObject')
-    @index.delete_user_key(newIndexKey['key'])
+    @index.delete_api_key(newIndexKey['key'])
     wait_key_missing(@index, newIndexKey['key'])
-    resIndexEnd = @index.list_user_keys
+    resIndexEnd = @index.list_api_keys
     is_include(resIndexEnd['keys'], 'value', newIndexKey['key']).should eq(false)
   end
 
   it "should test global keys" do
-    res = Algolia.list_user_keys
-    newKey = Algolia.add_user_key(['search'])
+    res = Algolia.list_api_keys
+    newKey = Algolia.add_api_key(['search'])
     newKey['key'].should_not eq("")
     wait_global_key(newKey['key'])
-    resAfter = Algolia.list_user_keys
+    resAfter = Algolia.list_api_keys
     is_include(res['keys'], 'value', newKey['key']).should eq(false)
     is_include(resAfter['keys'], 'value', newKey['key']).should eq(true)
-    key = Algolia.get_user_key(newKey['key'])
+    key = Algolia.get_api_key(newKey['key'])
     key['acl'][0].should eq('search')
-    Algolia.update_user_key(newKey['key'], ['addObject'])
+    Algolia.update_api_key(newKey['key'], ['addObject'])
     wait_global_key(newKey['key']) do |key|
       key['acl'] == ['addObject']
     end
-    key = Algolia.get_user_key(newKey['key'])
+    key = Algolia.get_api_key(newKey['key'])
     key['acl'][0].should eq('addObject')
-    Algolia.delete_user_key(newKey['key'])
+    Algolia.delete_api_key(newKey['key'])
     wait_global_key_missing(newKey['key'])
-    resEnd = Algolia.list_user_keys
+    resEnd = Algolia.list_api_keys
     is_include(resEnd['keys'], 'value', newKey['key']).should eq(false)
   end
 
@@ -692,13 +692,13 @@ describe 'Client' do
   end
 
   it "Check add keys" do
-    newIndexKey = @index.add_user_key(['search'])
+    newIndexKey = @index.add_api_key(['search'])
     newIndexKey.should have_key('key')
     newIndexKey['key'].should be_a(String)
     newIndexKey.should have_key('createdAt')
     newIndexKey['createdAt'].should be_a(String)
     sleep 5 # no task ID here
-    resIndex = @index.list_user_keys
+    resIndex = @index.list_api_keys
     resIndex.should have_key('keys')
     resIndex['keys'].should be_a(Array)
     resIndex['keys'][0].should have_key('value')
@@ -707,14 +707,14 @@ describe 'Client' do
     resIndex['keys'][0]['acl'].should be_a(Array)
     resIndex['keys'][0].should have_key('validity')
     resIndex['keys'][0]['validity'].should be_a(Integer)
-    indexKey = @index.get_user_key(newIndexKey['key'])
+    indexKey = @index.get_api_key(newIndexKey['key'])
     indexKey.should have_key('value')
     indexKey['value'].should be_a(String)
     indexKey.should have_key('acl')
     indexKey['acl'].should be_a(Array)
     indexKey.should have_key('validity')
     indexKey['validity'].should be_a(Integer)
-    task = @index.delete_user_key(newIndexKey['key'])
+    task = @index.delete_api_key(newIndexKey['key'])
     task.should have_key('deletedAt')
     task['deletedAt'].should be_a(String)
   end

--- a/spec/mock_spec.rb
+++ b/spec/mock_spec.rb
@@ -19,7 +19,7 @@ describe 'With a mocked client' do
     index = Algolia::Index.new("friends")
     index.add_object!({ :name => "John Doe", :email => "john@doe.org" })
     index.search('').should == { "hits" => [ { "objectID" => 42 } ], "page" => 1, "hitsPerPage" => 1 } # mocked
-    index.list_user_keys
+    index.list_api_keys
     index.browse
     index.clear
     index.delete


### PR DESCRIPTION
@redox, would love your eyes on this one. I'm not entirely sure how we handled method renaming in the past.