### PR TITLE
Add get_task_status method to Algolia::Index class.

### DIFF
--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -235,6 +235,15 @@ module Algolia
       client.post(Protocol.objects_uri, { :requests => requests }.to_json, :read)['results']
     end
 
+    # Check the status of a task on the server.
+    # All server task are asynchronous and you can check the status of a task with this method.
+    #
+    # @param taskID the id of the task returned by server
+    #
+    def get_task_status(taskID)
+      client.get(Protocol.task_uri(name, taskID), :read)["status"]
+    end
+
     # Wait the publication of a task on the server.
     # All server task are asynchronous and you can check with this method that the task is published.
     #
@@ -243,7 +252,7 @@ module Algolia
     #
     def wait_task(taskID, timeBeforeRetry = 100)
       loop do
-        status = client.get(Protocol.task_uri(name, taskID), :read)["status"]
+        status = get_task_status(taskID)
         if status == "published"
           return
         end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -691,6 +691,12 @@ describe 'Client' do
     [true, false].should include(task['pendingTask'])
   end
 
+  it 'Check attributes get_task_status' do
+    task = @index.add_object!({ :name => "John Doe", :email => "john@doe.org" }, "1")
+    status = @index.get_task_status(task["taskID"])
+    status.should be_a(String)
+  end
+
   it "Check add keys" do
     newIndexKey = @index.add_api_key(['search'])
     newIndexKey.should have_key('key')

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -693,7 +693,7 @@ describe 'Client' do
 
   it 'Check attributes get_task_status' do
     task = @index.add_object!({ :name => "John Doe", :email => "john@doe.org" }, "1")
-    status = @index.get_task_status(task["taskID"])
+    status = @index.get_task_status(task["objectID"])
     status.should be_a(String)
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -693,7 +693,7 @@ describe 'Client' do
 
   it 'Check attributes get_task_status' do
     task = @index.add_object!({ :name => "John Doe", :email => "john@doe.org" }, "1")
-    status = @index.get_task_status(task["objectID"])
+    status = @index.get_task_status(task["taskID"])
     status.should be_a(String)
   end
 


### PR DESCRIPTION
After looking through the source of this library I realized that there wasn't a way to just check the status of a task instead of waiting for a task to finish. So I decided to create a pull request in the hopes that you guys would merge it and add this functionality. I could really use it.