### PR TITLE
chore(browse): improve the default implementation

### DIFF
--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -193,6 +193,7 @@ module Algolia
       else
         params[:page] ||= 0
         params[:hitsPerPage] ||= 1000
+        params[:distinct] ||= false
         client.get(Protocol.browse_uri(name, params), :read)
       end
     end


### PR DESCRIPTION
This should avoid the case where a user sets `distinct: 2` in his/her index settings and the API fail with `hitsPerPage * distinct should be <= 1000`.