### PR TITLE
Improve delete_by_query performance for queries that return more than 1000 hits

### DIFF
--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -412,9 +412,10 @@ module Algolia
         result = browse(params)
 
         params[:cursor] = result['cursor']
-        break unless result.has_key?('hits')
 
         hits = result['hits']
+        break if hits.empty?
+
         ids += hits.map { |h| h['objectID'] }
       end
 

--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -838,5 +838,13 @@ module Algolia
       }
     end
 
+    def sanitized_delete_by_query_params(params)
+      params ||= {}
+      params.delete(:hitsPerPage)
+      params.delete('hitsPerPage')
+      params.delete(:attributesToRetrieve)
+      params.delete('attributesToRetrieve')
+      params
+    end
   end
 end

--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -412,6 +412,8 @@ module Algolia
         result = browse(params)
 
         params[:cursor] = result['cursor']
+        break unless result.has_key?('hits')
+
         hits = result['hits']
         ids += hits.map { |h| h['objectID'] }
       end

--- a/lib/algolia/webmock.rb
+++ b/lib/algolia/webmock.rb
@@ -29,7 +29,7 @@ WebMock.stub_request(:post, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+\/ba
 WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+\/settings/).to_return(:body => '{}')
 WebMock.stub_request(:put, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+\/settings/).to_return(:body => '{ "taskID": 42 }')
 # browse
-WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+\/browse/).to_return(:body => '{}')
+WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+\/browse/).to_return(:body => '{ "hits": [] }')
 # operations
 WebMock.stub_request(:post, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+\/operation/).to_return(:body => '{ "taskID": 42 }')
 # tasks


### PR DESCRIPTION
[As suggested](https://github.com/algolia/algoliasearch-client-ruby/pull/209#discussion_r128988549) by @raphi in #209, add a new version of `delete_by_query` that scans the entire index for all IDs to delete without awaiting delete results like in the old `delete_by_query` (which is now `delete_by_query!`) and then delete all matching objects asynchronously through one call to `delete_objects`.

This should solve #204 and provide a better-performing solution when dealing with a query that attempts to delete more than 1000 objects than my previous PR #208 and also #209.