### PR TITLE
Fix missing 'nbHits' and 'nbPages' JSON objects in the webmock file

### DIFF
--- a/lib/algolia/webmock.rb
+++ b/lib/algolia/webmock.rb
@@ -8,7 +8,7 @@ end
 # list indexes
 WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes/).to_return(:body => '{ "items": [] }')
 # query index
-WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "hits": [ { "objectID": 42 } ], "page": 1, "hitsPerPage": 1 }')
+WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "hits": [ { "objectID": 42 } ], "page": 1, "hitsPerPage": 1, "nbHits": 1, "nbPages": 1 }')
 # delete index
 WebMock.stub_request(:delete, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "taskID": 42 }')
 # clear index
@@ -43,4 +43,4 @@ WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/keys/).to_return(:bo
 WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/keys\/[^\/]+/).to_return(:body => '{ }')
 WebMock.stub_request(:delete, /.*\.algolia(net\.com|\.net)\/1\/keys\/[^\/]+/).to_return(:body => '{ }')
 # query POST
-WebMock.stub_request(:post, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+\/query/).to_return(:body => '{ "hits": [ { "objectID": 42 } ], "page": 1, "hitsPerPage": 1 }')
+WebMock.stub_request(:post, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+\/query/).to_return(:body => '{ "hits": [ { "objectID": 42 } ], "page": 1, "hitsPerPage": 1, "nbHits": 1, "nbPages": 1 }')


### PR DESCRIPTION
I'm currently having the error below and realized that there's something missing in the stubs' return JSON payload. With the changes the error was eliminated.

```
     NoMethodError:
       undefined method `*' for nil:NilClass
     # /home/vagrant/.rvm/gems/ruby-2.3.4/gems/algoliasearch-rails-1.19.1/lib/algoliasearch-rails.rb:659:in `algolia_search'
     # ./app/models/concerns/search_engine/algolia.rb:35:in `search'
     # ./app/services/lead_services/search.rb:4:in `execute'
     # ./app/controllers/api/leads_controller.rb:110:in `search'
     # /home/vagrant/.rvm/gems/ruby-2.3.4/gems/devise-3.5.6/lib/devise/test_helpers.rb:19:in `block in process'
     # /home/vagrant/.rvm/gems/ruby-2.3.4/gems/devise-3.5.6/lib/devise/test_helpers.rb:72:in `catch'
     # /home/vagrant/.rvm/gems/ruby-2.3.4/gems/devise-3.5.6/lib/devise/test_helpers.rb:72:in `_catch_warden'
     # /home/vagrant/.rvm/gems/ruby-2.3.4/gems/devise-3.5.6/lib/devise/test_helpers.rb:19:in `process'
     # /home/vagrant/.rvm/gems/ruby-2.3.4/gems/gon-6.1.0/lib/gon/spec_helpers.rb:15:in `process'
     # ./spec/controllers/api/leads_controller_spec.rb:264:in `block (4 levels) in <top (required)>'
```