### PR TITLE
Fix get_logs always returning type `all`

### DIFF
--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -185,6 +185,7 @@ module Algolia
     #
     # @param offset Specify the first entry to retrieve (0-based, 0 is the most recent log entry).
     # @param length Specify the maximum number of entries to retrieve starting at offset. Maximum allowed value: 1000.
+    # @param type Optional type of log entries to retrieve ("all", "query", "build" or "error").
     #
     def get_logs(offset = 0, length = 10, type = "all")
       if (type.is_a?(true.class))

--- a/lib/algolia/protocol.rb
+++ b/lib/algolia/protocol.rb
@@ -101,8 +101,8 @@ module Algolia
       "#{index_uri(index)}/clear"
     end
 
-    def Protocol.logs(offset, length, only_errors = false)
-      "/#{VERSION}/logs?offset=#{offset}&length=#{length}&onlyErrors=#{only_errors}"
+    def Protocol.logs(offset, length, type)
+      "/#{VERSION}/logs?offset=#{offset}&length=#{length}&type=#{type}"
     end
 
     def Protocol.keys_uri

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -325,6 +325,7 @@ describe 'Client' do
     res = Algolia.get_logs(0, 20, true)
 
     res['logs'].size.should > 0
+    res['logs'].each { |log| log['answer_code'].should eq("404") }
   end
 
   it "should search on multipleIndex" do


### PR DESCRIPTION
Closes https://github.com/algolia/algoliasearch-client-ruby/issues/241