### PR TITLE
Do not setup Bundle or RubyGems

### DIFF
--- a/lib/algoliasearch.rb
+++ b/lib/algoliasearch.rb
@@ -4,9 +4,6 @@
 ## A quick library for playing with algolia.com's REST API for object storage.
 ## Thanks to Sylvain Utard for the initial version of the library (sylvain.utard@gmail.com)
 ## ----------------------------------------------------------------------
-require "rubygems"
-require "bundler/setup"
-
 require 'json'
 if !defined?(RUBY_ENGINE) && defined?(RUBY_VERSION) && RUBY_VERSION == '1.8.7'
   # work-around a limitation from nahi/httpclient, using the undefined RUBY_ENGINE constant


### PR DESCRIPTION
With these statements, the AlgoliaSearch family of gems breaks our application on CI, as both the Gem and our host app require and initialize Bundler. 

Since upgrading to Bundler 1.16, starting our app on CI fails with
``` 
Bundler::GemRequireError: There was an error while trying to load the gem 'algoliasearch-rails'.
Gem Load Error is: Trying to register Bundler::GemfileError for status code 4 but Bundler::GemfileError is already registered
Backtrace for gem load error is:
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.16.0/lib/bundler/errors.rb:9:in `status_code'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.16.0/lib/bundler/errors.rb:20:in `<class:GemfileError>'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.16.0/lib/bundler/errors.rb:20:in `<module:Bundler>'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.16.0/lib/bundler/errors.rb:3:in `<main>'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.16.0/lib/bundler.rb:10:in `<main>'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.16.0/lib/bundler/setup.rb:6:in `<main>'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/algoliasearch-1.18.2/lib/algoliasearch.rb:8:in `<main>'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/bundler/gems/algoliasearch-rails-a458bd8ff9bc/lib/algoliasearch-rails.rb:1:in `<main>'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:50:in `require'
/home/circleci/cspree/vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:50:in `require'
/usr/local/lib/ruby/site_ruby/2.3.0/bundler/runtime.rb:81:in `block (2 levels) in require'
/usr/local/lib/ruby/site_ruby/2.3.0/bundler/runtime.rb:76:in `each'
/usr/local/lib/ruby/site_ruby/2.3.0/bundler/runtime.rb:76:in `block in require'
/usr/local/lib/ruby/site_ruby/2.3.0/bundler/runtime.rb:65:in `each'
/usr/local/lib/ruby/site_ruby/2.3.0/bundler/runtime.rb:65:in `require'
/usr/local/lib/ruby/site_ruby/2.3.0/bundler.rb:114:in `require'
/home/circleci/cspree/config/application.rb:7:in `<top (required)>'
/home/circleci/cspree/Rakefile:4:in `require'
/home/circleci/cspree/Rakefile:4:in `<top (required)>'
```

As I do not feel my libraries should be requiring my library management software, and removing those requires fixes the startup bug... Maybe remove those lines?