### PR TITLE
Fix `hashdiff` wrong dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,10 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Load algoliasearch.gemspec dependencies
 gemspec
 
-# if RUBY_VERSION < '1.9.3'
-#   gem 'hashdiff', '< 0.3.6' # Hashdiff 0.3.6 no longer supports Ruby 1.8
-# end
+# See https://github.com/algolia/algoliasearch-client-ruby/pull/257/files/36bcd0b1c4d05776dcbdb362c15a609c81f41cde
+if RUBY_VERSION < '1.9.3'
+  gem 'hashdiff', '< 0.3.6' # Hashdiff 0.3.6 no longer supports Ruby 1.8
+end
 
 gem 'rubysl', '~> 2.0', :platform => :rbx
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Load algoliasearch.gemspec dependencies
 gemspec
 
+if RUBY_VERSION < '1.9.3'
+  gem 'hashdiff', '< 0.3.6' # Hashdiff 0.3.6 no longer supports Ruby 1.8
+end
+
 gem 'rubysl', '~> 2.0', :platform => :rbx
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Load algoliasearch.gemspec dependencies
 gemspec
 
-if RUBY_VERSION < '1.9.3'
-  gem 'hashdiff', '< 0.3.6' # Hashdiff 0.3.6 no longer supports Ruby 1.8
-end
+# if RUBY_VERSION < '1.9.3'
+#   gem 'hashdiff', '< 0.3.6' # Hashdiff 0.3.6 no longer supports Ruby 1.8
+# end
 
 gem 'rubysl', '~> 2.0', :platform => :rbx
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 # See https://github.com/algolia/algoliasearch-client-ruby/pull/257/files/36bcd0b1c4d05776dcbdb362c15a609c81f41cde
-if RUBY_VERSION < '1.9.3'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('1.9.3')
   gem 'hashdiff', '< 0.3.6' # Hashdiff 0.3.6 no longer supports Ruby 1.8
 end
 

--- a/algoliasearch.gemspec
+++ b/algoliasearch.gemspec
@@ -53,18 +53,15 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<httpclient>, ["~> 2.8.3"])
       s.add_runtime_dependency(%q<json>, [">= 1.5.1"])
-      s.add_runtime_dependency(%q<hashdiff>, "0.3.5")
       s.add_development_dependency "travis"
       s.add_development_dependency "rake"
       s.add_development_dependency "rdoc"
     else
       s.add_dependency(%q<httpclient>, ["~> 2.8.3"])
       s.add_dependency(%q<json>, [">= 1.5.1"])
-      s.add_dependency(%q<hashdiff>, "0.3.5")
     end
   else
     s.add_dependency(%q<httpclient>, ["~> 2.8.3"])
     s.add_dependency(%q<json>, [">= 1.5.1"])
-    s.add_dependency(%q<hashdiff>, "0.3.5")
   end
 end


### PR DESCRIPTION
Attempt to fix hardcoded dependency due to `hashdiff` wrong dependency declaration (https://github.com/algolia/algoliasearch-client-ruby/pull/257/files/36bcd0b1c4d05776dcbdb362c15a609c81f41cde)