### PR TITLE
Add support of HTTP_PROXY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ index.set_settings searchableAttributes: %w(
 )
 ```
 
+**Note:** If you are behind a proxy, set `HTTP_PROXY` environment variable.
+
 ## Search
 
 You can now search for contacts using `firstname`, `lastname`, `company`, etc. (even with typos):

--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -439,7 +439,7 @@ module Algolia
     def thread_local_hosts(read)
       thread_hosts_key = read ? "algolia_search_hosts_#{application_id}" : "algolia_hosts_#{application_id}"
       Thread.current[thread_hosts_key] ||= (read ? search_hosts : hosts).each_with_index.map do |host, i|
-        client = HTTPClient.new
+        client = HTTPClient.new(ENV["HTTP_PROXY"])
         client.ssl_config.ssl_version = @ssl_version if @ssl && @ssl_version
         client.transparent_gzip_decompression = @gzip
         client.ssl_config.add_trust_ca File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'resources', 'ca-bundle.crt'))


### PR DESCRIPTION
This PR adds support of `HTTP_PROXY` environment variable to the gem like in the JavaScript client: https://github.com/algolia/algoliasearch-client-javascript#proxy-support

If the environment variable is not set, the code behave as usual.

See https://github.com/nahi/httpclient/blob/v2.8.3/sample/thread.rb#L7