### PR TITLE
UserAgent: Add ruby version

### DIFF
--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -21,7 +21,7 @@ module Algolia
     DEFAULT_SEND_TIMEOUT    = 30
     DEFAULT_BATCH_TIMEOUT   = 120
     DEFAULT_SEARCH_TIMEOUT  = 5
-    DEFAULT_USER_AGENT      = ["Ruby (#{RUBY_VERSION})", "Algolia for Ruby (#{::Algolia::VERSION})"]
+    DEFAULT_USER_AGENT      = ["Algolia for Ruby (#{::Algolia::VERSION})", "Ruby (#{RUBY_VERSION})"]
 
     def initialize(data = {})
       raise ArgumentError.new('No APPLICATION_ID provided, please set :application_id') if data[:application_id].nil?

--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -41,7 +41,7 @@ module Algolia
         Protocol::HEADER_API_KEY => api_key,
         Protocol::HEADER_APP_ID  => application_id,
         'Content-Type'           => 'application/json; charset=utf-8',
-        'User-Agent'             => (data[:user_agent] || "Algolia for Ruby #{::Algolia::VERSION}")
+        'User-Agent'             => format_user_agent(data[:user_agent])
       }
     end
 
@@ -547,6 +547,12 @@ module Algolia
 
       request_options['headers'].merge!(headers_to_add)
       request_options
+    end
+
+    def format_user_agent(custom)
+      ua = "Ruby (#{RUBY_VERSION}); Algolia for Ruby (#{::Algolia::VERSION})"
+      ua.concat("; "  + custom.to_s) if custom
+      ua
     end
 
     # Deprecated

--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -21,6 +21,7 @@ module Algolia
     DEFAULT_SEND_TIMEOUT    = 30
     DEFAULT_BATCH_TIMEOUT   = 120
     DEFAULT_SEARCH_TIMEOUT  = 5
+    DEFAULT_USER_AGENT      = ["Ruby (#{RUBY_VERSION})", "Algolia for Ruby (#{::Algolia::VERSION})"]
 
     def initialize(data = {})
       raise ArgumentError.new('No APPLICATION_ID provided, please set :application_id') if data[:application_id].nil?
@@ -41,7 +42,7 @@ module Algolia
         Protocol::HEADER_API_KEY => api_key,
         Protocol::HEADER_APP_ID  => application_id,
         'Content-Type'           => 'application/json; charset=utf-8',
-        'User-Agent'             => format_user_agent(data[:user_agent])
+        'User-Agent'             => DEFAULT_USER_AGENT.push(data[:user_agent]).compact.join('; ')
       }
     end
 
@@ -547,12 +548,6 @@ module Algolia
 
       request_options['headers'].merge!(headers_to_add)
       request_options
-    end
-
-    def format_user_agent(custom)
-      ua = "Ruby (#{RUBY_VERSION}); Algolia for Ruby (#{::Algolia::VERSION})"
-      ua.concat("; "  + custom.to_s) if custom
-      ua
     end
 
     # Deprecated

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1173,7 +1173,7 @@ describe 'Client' do
         to_return(:status => 200, :body => '{}')
       @client.list_indexes
       expect(WebMock).to have_requested(:get, /https:\/\/.+-dsn.algolia(net\.com|\.net)\/1\/indexes/).
-        with(:headers => { 'User-Agent' => "Ruby (#{RUBY_VERSION}); Algolia for Ruby (#{::Algolia::VERSION}); test agent" })
+        with(:headers => { 'User-Agent' => "Algolia for Ruby (#{::Algolia::VERSION}); Ruby (#{RUBY_VERSION}); test agent" })
     end
 
     after(:all) do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1160,8 +1160,11 @@ describe 'Client' do
     end
 
     before(:each) do
-      @client = Algolia::Client.new :application_id => ENV['ALGOLIA_APPLICATION_ID'], :api_key => ENV['ALGOLIA_API_KEY'],
+      @client = Algolia::Client.new(
+        :application_id => ENV['ALGOLIA_APPLICATION_ID'],
+        :api_key => ENV['ALGOLIA_API_KEY'],
         :user_agent => 'test agent'
+      )
       @client.destroy # make sure the thread-local vars are reseted
     end
 
@@ -1170,7 +1173,7 @@ describe 'Client' do
         to_return(:status => 200, :body => '{}')
       @client.list_indexes
       expect(WebMock).to have_requested(:get, /https:\/\/.+-dsn.algolia(net\.com|\.net)\/1\/indexes/).
-        with(:headers => {'User-Agent' => 'test agent'})
+        with(:headers => { 'User-Agent' => "Ruby (#{RUBY_VERSION}); Algolia for Ruby (#{::Algolia::VERSION}); test agent" })
     end
 
     after(:all) do

--- a/spec/stub_spec.rb
+++ b/spec/stub_spec.rb
@@ -16,7 +16,7 @@ describe 'With a rate limited client' do
 
   it "should pass the right headers" do
     WebMock.stub_request(:post, %r{https://.*\.algolia\.(io|net)/1/indexes/friends/query}).
-      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Ruby (#{RUBY_VERSION}); Algolia for Ruby (#{Algolia::VERSION})", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'], 'X-Forwarded-Api-Key'=>'ratelimitapikey', 'X-Forwarded-For'=>'1.2.3.4'}).
+      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Algolia for Ruby (#{Algolia::VERSION}); Ruby (#{RUBY_VERSION})", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'], 'X-Forwarded-Api-Key'=>'ratelimitapikey', 'X-Forwarded-For'=>'1.2.3.4'}).
       to_return(:status => 200, :body => "{ \"hits\": [], \"fakeAttribute\": 1 }", :headers => {})
     Algolia.enable_rate_limit_forward ENV['ALGOLIA_API_KEY'], "1.2.3.4", "ratelimitapikey"
     index = Algolia::Index.new("friends")
@@ -26,7 +26,7 @@ describe 'With a rate limited client' do
 
   it "should use original headers" do
     WebMock.stub_request(:post, %r{https://.*\.algolia\.(io|net)/1/indexes/friends/query}).
-      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Ruby (#{RUBY_VERSION}); Algolia for Ruby (#{Algolia::VERSION})", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'] }).
+      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Algolia for Ruby (#{Algolia::VERSION}); Ruby (#{RUBY_VERSION})", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'] }).
       to_return(:status => 200, :body => "{ \"hits\": [], \"fakeAttribute\": 2 }", :headers => {})
     Algolia.disable_rate_limit_forward
     index = Algolia::Index.new("friends")
@@ -35,7 +35,7 @@ describe 'With a rate limited client' do
 
   it "should pass the right headers in the scope" do
     WebMock.stub_request(:post, %r{https://.*\.algolia\.(io|net)/1/indexes/friends/query}).
-      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Ruby (#{RUBY_VERSION}); Algolia for Ruby (#{Algolia::VERSION})", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'], 'X-Forwarded-Api-Key'=>'ratelimitapikey', 'X-Forwarded-For'=>'1.2.3.4'}).
+      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Algolia for Ruby (#{Algolia::VERSION}); Ruby (#{RUBY_VERSION})", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'], 'X-Forwarded-Api-Key'=>'ratelimitapikey', 'X-Forwarded-For'=>'1.2.3.4'}).
       to_return(:status => 200, :body => "{ \"hits\": [], \"fakeAttribute\": 1 }", :headers => {})
     Algolia.with_rate_limits "1.2.3.4", "ratelimitapikey" do
       index = Algolia::Index.new("friends")

--- a/spec/stub_spec.rb
+++ b/spec/stub_spec.rb
@@ -16,7 +16,7 @@ describe 'With a rate limited client' do
 
   it "should pass the right headers" do
     WebMock.stub_request(:post, %r{https://.*\.algolia\.(io|net)/1/indexes/friends/query}).
-      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Algolia for Ruby #{Algolia::VERSION}", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'], 'X-Forwarded-Api-Key'=>'ratelimitapikey', 'X-Forwarded-For'=>'1.2.3.4'}).
+      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Ruby (#{RUBY_VERSION}); Algolia for Ruby (#{Algolia::VERSION})", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'], 'X-Forwarded-Api-Key'=>'ratelimitapikey', 'X-Forwarded-For'=>'1.2.3.4'}).
       to_return(:status => 200, :body => "{ \"hits\": [], \"fakeAttribute\": 1 }", :headers => {})
     Algolia.enable_rate_limit_forward ENV['ALGOLIA_API_KEY'], "1.2.3.4", "ratelimitapikey"
     index = Algolia::Index.new("friends")
@@ -26,8 +26,8 @@ describe 'With a rate limited client' do
 
   it "should use original headers" do
     WebMock.stub_request(:post, %r{https://.*\.algolia\.(io|net)/1/indexes/friends/query}).
-      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Algolia for Ruby #{Algolia::VERSION}", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'] }).
-      to_return(:status => 200, :body => "{ \"hits\": [], \"fakeAttribute\": 2 }", :headers => {})    
+      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Ruby (#{RUBY_VERSION}); Algolia for Ruby (#{Algolia::VERSION})", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'] }).
+      to_return(:status => 200, :body => "{ \"hits\": [], \"fakeAttribute\": 2 }", :headers => {})
     Algolia.disable_rate_limit_forward
     index = Algolia::Index.new("friends")
     index.search('bar')['fakeAttribute'].should == 2
@@ -35,7 +35,7 @@ describe 'With a rate limited client' do
 
   it "should pass the right headers in the scope" do
     WebMock.stub_request(:post, %r{https://.*\.algolia\.(io|net)/1/indexes/friends/query}).
-      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Algolia for Ruby #{Algolia::VERSION}", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'], 'X-Forwarded-Api-Key'=>'ratelimitapikey', 'X-Forwarded-For'=>'1.2.3.4'}).
+      with(:headers => {'Content-Type'=>'application/json; charset=utf-8', 'User-Agent'=>"Ruby (#{RUBY_VERSION}); Algolia for Ruby (#{Algolia::VERSION})", 'X-Algolia-Api-Key'=>ENV['ALGOLIA_API_KEY'], 'X-Algolia-Application-Id'=>ENV['ALGOLIA_APPLICATION_ID'], 'X-Forwarded-Api-Key'=>'ratelimitapikey', 'X-Forwarded-For'=>'1.2.3.4'}).
       to_return(:status => 200, :body => "{ \"hits\": [], \"fakeAttribute\": 1 }", :headers => {})
     Algolia.with_rate_limits "1.2.3.4", "ratelimitapikey" do
       index = Algolia::Index.new("friends")


### PR DESCRIPTION
We'd like to add the language version to each client. Today everything is overridden if you pass a user-agent value to the constructor of the Client class. 
I'd rather leave the client and language version and let users add something specific at the end.

Any comment is welcome.

Pull request on Rails is coming.