### PR TITLE
fix: Prevent saving a rule with an empty objectID

### DIFF
--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -948,6 +948,7 @@ module Algolia
     # @param forward_to_replicas should we forward the delete to replica indices
     # @param request_options contains extra parameters to send with your query
     def save_rule(objectID, rule, forward_to_replicas = false, request_options = {})
+      raise ArgumentError.new('objectID must not be blank') if objectID.nil? || objectID == ''
       client.put("#{Protocol.rule_uri(name, objectID)}?forwardToReplicas=#{forward_to_replicas}", rule.to_json, :write, request_options)
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1107,6 +1107,17 @@ describe 'Client' do
     @index.search_rules('')['nbHits'].should eq(0)
   end
 
+  it 'should not save a query rule with an empty objectID' do
+    rule = {
+      :objectID => '',
+      :condition => { :pattern => 'test', :anchoring => 'contains' },
+      :consequence => { :params => { :query => 'this is better' } }
+    }
+
+    expect { @index.save_rule!(nil, rule) }.to raise_error(ArgumentError)
+    expect { @index.save_rule!(rule[:objectID], rule) }.to raise_error(ArgumentError)
+  end
+
   it "should use request options" do
     expect{Algolia.list_indexes}.to_not raise_error
 


### PR DESCRIPTION
First time for years I'm writing Ruby. Absolutely any comment is more than welcome.