### PR TITLE
Deprecate Index::add_api_key for Client::add_api_key

### DIFF
--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -566,6 +566,7 @@ module Algolia
     #  @param maxHitsPerQuery  the maximum number of hits this API key can retrieve in one call (0 means unlimited)
     #  @param request_options contains extra parameters to send with your query
     #
+    # Deprecated: use `add_api_key` on the client instead
     def add_api_key(obj, validity = 0, maxQueriesPerIPPerHour = 0, maxHitsPerQuery = 0, request_options = {})
       if obj.instance_of? Array
         params = {


### PR DESCRIPTION
Same as algolia/algoliasearch-client-php#378

All keys should be managed using the Client class.

If you use the Index class, you'll attached the key to the index internally. They are not displayed in the dashboard and cannot be retrieve with client::list_api_keys. This is a deprecated feature, that shouldn't be used anymore.

Instead, you can create a key using client::add_api_key that will be attached to the Application internally. You can add restriction on the index to achieve the same behavior.

Other methods like get, update, delete, list are still required to access your existing keys.