### PR TITLE
fix(tests): Fix warning for unspecified exception

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1121,7 +1121,7 @@ describe 'Client' do
   it "should use request options" do
     expect{Algolia.list_indexes}.to_not raise_error
 
-    expect{Algolia.list_indexes('headers' => { 'X-Algolia-API-Key' => 'NotExistentAPIKey' })}.to raise_error
+    expect{Algolia.list_indexes('headers' => { 'X-Algolia-API-Key' => 'NotExistentAPIKey' })}.to raise_error(Algolia::AlgoliaProtocolError)
   end
 
   context 'DNS timeout' do


### PR DESCRIPTION
Remove the following warning:

```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<Algolia::AlgoliaProtocolError: 403: Cannot GET to https://K7MLRQH1JG-dsn.algolia.net/1/indexes: {"message":"Invalid Application-ID or API key","status":403}
 (403)>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/julien/Algolia/API-clients/ruby/spec/client_spec.rb:1124:in `block (2 levels) in <top (required)>'.
```

See: https://travis-ci.org/algolia/algoliasearch-client-ruby/jobs/375815772#L744