### PR TITLE
Rake: use unshift to keep compat with older ruby versions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ namespace :algolia do
     title = "## [%s](%s%s) (%s)\n\n" % [args[:version], GIT_TAG_URL, args[:version], last_commit_date]
     changes = changelog.each_line
                        .map { |line| (exceptions_regexp === line) ? nil : "* #{line.capitalize}" }
-                       .prepend(title)
+                       .unshift(title)
                        .append("\n\n")
                        .join
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## What was changed

the `prepend` method is an alias to `unshift` but was introduced in Ruby 2.5. In order to keep the script working with older version of ruby, we move back to unshift.
