### PR TITLE
Tests: make MCM tests more stable

### DIFF
--- a/spec/client_mcm_spec.rb
+++ b/spec/client_mcm_spec.rb
@@ -46,11 +46,13 @@ describe 'Multi Cluster Management', :mcm => true do
 
   it 'should assign a user to a cluster' do
     @client.assign_user_id(@user_id, @cluster_name)
-    sleep(2)
   end
 
   it 'should get the created user id' do
-    id = @client.get_user_id(@user_id)
+    id = auto_retry do
+      @client.get_user_id(@user_id)
+    end
+
     id["userID"].should eq(@user_id)
     id["clusterName"].should eq(@cluster_name)
     id.has_key?("nbRecords").should eq(true)
@@ -66,13 +68,10 @@ describe 'Multi Cluster Management', :mcm => true do
   end
 
   it "should remove a user_id" do
-    res = @client.remove_user_id(@user_id)
-    sleep(2)
-    search = @client.search_user_id(@user_id)
-    if search["nbHits"] > 0
-      item = search["hits"][0]
-      item["userID"].should_not eq(@user_id)
+    res = auto_retry do
+      @client.remove_user_id(@user_id)
     end
+    res["deletedAt"].should_not eq(nil)
   end
 
 end

--- a/spec/client_mcm_spec.rb
+++ b/spec/client_mcm_spec.rb
@@ -1,10 +1,14 @@
 # encoding: UTF-8
 require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
+require 'securerandom'
 
 # avoid concurrent access to the same index
 def safe_user_id(name)
-  return name if ENV['TRAVIS'].to_s != "true"
-  "#{name}-#{ENV['TRAVIS_JOB_NUMBER']}"
+  name << '-' + SecureRandom.hex(4)
+  if ENV['TRAVIS'].to_s == 'true'
+    name << '-' + ENV['TRAVIS_JOB_NUMBER'].to_s
+  end
+  name
 end
 
 describe 'Multi Cluster Management', :mcm => true do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,3 +35,23 @@ RSpec.configure do |config|
     WebMock.disable!
   end
 end
+
+def auto_retry(options = {})
+  return if !block_given?
+
+  max_retry = options[:max_retry] || 10
+  retry_count = 0
+
+  loop do
+    begin
+      return yield
+    rescue => e
+      retry_count += 1
+      if retry_count >= max_retry
+        raise e
+      else
+        sleep retry_count
+      end
+    end
+  end
+end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## What was changed

I introduce a new helper functions in test called `auto_retry`. Some operations are asynchronous but the engine doesn't return a taskID. This function execute a block and retry multiple times before failing.

For MCM, if a userID wasn't assigned before we try to retrieve or delete, it would fail. With `auto_retry` we wait a few seconds and try agian before failing.

Another thing, when you search for a userID, you might not find the one you want because there is one with a close name ranked higher. I fixed that by using a unique userID for every build.

## Why it was changed

New MCM tests were making the build very unstable.