### PR TITLE
Expose waitTask in the client

### DIFF
--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -272,7 +272,7 @@ module Algolia
     # @param request_options contains extra parameters to send with your query
     #
     def get_task_status(taskID, request_options = {})
-      client.get(Protocol.task_uri(name, taskID), :read, request_options)['status']
+      client.get_task_status(name, taskID, request_options)
     end
 
     #
@@ -284,13 +284,7 @@ module Algolia
     # @param request_options contains extra parameters to send with your query
     #
     def wait_task(taskID, time_before_retry = WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY, request_options = {})
-      loop do
-        status = get_task_status(taskID, request_options)
-        if status == 'published'
-          return
-        end
-        sleep(time_before_retry.to_f / 1000)
-      end
+      client.wait_task(name, taskID, time_before_retry, request_options)
     end
 
     #


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | yes (not sure)


## What was changed

2 methods about taskID initially available in the `Index` moved to the `Client`. The original methods on the index still work and are **not** deprecated.

```ruby
# New 🎉
client.wait_task(index_name, taskID, time_before_retry, requestHeaders)
client.get_task_status(index_name, taskID, requestHeaders)

# Still available
index.wait_task(taskID)
index.get_task_status(taskID, requestHeaders)
```

## Why it was changed

You could get some taskID from the engine without necessarily have an instance of Index. Instead of instanciating an index that you won't need, you can now call `waitTask` and `getTaskStatus` on the client.

* In the ruby client, bang methods (like `batch!` will instanciate an index, that use the client to call the API. We're now using the wait_task in the client directly
* It will be very useful for the new Analytics object (see https://github.com/algolia/algoliasearch-client-php/pull/408)
* We're planning to merge https://github.com/algolia/algoliasearch-client-php/pull/295 (and port it to all clients). Adding multipleObjects will be easier to use if waitTask lives in the Client.
* It was also discussed before for the Django integration ([here](https://github.com/algolia/algoliasearch-django/pull/258)).
