### PR TITLE
Prepend custom user agent

### DIFF
--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -42,7 +42,7 @@ module Algolia
         Protocol::HEADER_API_KEY => api_key,
         Protocol::HEADER_APP_ID  => application_id,
         'Content-Type'           => 'application/json; charset=utf-8',
-        'User-Agent'             => DEFAULT_USER_AGENT.prepend(data[:user_agent]).compact.join('; ')
+        'User-Agent'             => DEFAULT_USER_AGENT.unshift(data[:user_agent]).compact.join('; ')
       }
     end
 

--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -42,7 +42,7 @@ module Algolia
         Protocol::HEADER_API_KEY => api_key,
         Protocol::HEADER_APP_ID  => application_id,
         'Content-Type'           => 'application/json; charset=utf-8',
-        'User-Agent'             => DEFAULT_USER_AGENT.push(data[:user_agent]).compact.join('; ')
+        'User-Agent'             => DEFAULT_USER_AGENT.prepend(data[:user_agent]).compact.join('; ')
       }
     end
 


### PR DESCRIPTION
This should fix this issue https://github.com/algolia/AlgoliaWeb/issues/3515#issuecomment-402992627 by making sure the custom user agent is displayed first

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no  
| BC breaks?        | no     
| Related Issue     | Fix #310
| Need Doc update   | no


## What was changed
Prepends `data[:user_agent]` instead of appending it to `DEFAULT_USER_AGENT`

## Why it was changed
This behavior corrects expected order from Dashboard and possibly other systems

