### PR TITLE
feat(Client): added AlgoliaBadRequestError

### DIFF
--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -568,6 +568,9 @@ module Algolia
       when :DELETE
         session.delete(url, { :header => hs })
       end
+      if response.code / 100 == 4
+        raise AlgoliaBadRequestError.new(response.code, "Cannot #{method} to #{url}: #{response.content} (#{response.code})", response.content)
+      end
       if response.code / 100 != 2
         raise AlgoliaProtocolError.new(response.code, "Cannot #{method} to #{url}: #{response.content} (#{response.code})")
       end

--- a/lib/algolia/error.rb
+++ b/lib/algolia/error.rb
@@ -20,4 +20,16 @@ module Algolia
     end
   end
 
+  # An exception class which extends AlgoliaProtocolError by providing
+  # the raw api message as attribute.
+  class AlgoliaBadRequestError < AlgoliaProtocolError
+    attr_accessor :raw_api_response
+
+    def initialize(code, message, raw_api_response)
+      self.raw_api_response = raw_api_response
+
+      super(code, message)
+    end
+  end
+
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes 
| BC breaks?        | no     
| Related Issue     |  #28 
| Need Doc update   | yes


## What was changed

Add a new Error (AlgoliaBadRequestError), which contains the raw, parsable, api response.
Make the client throw this error when Algolia API responds a 400.

## Why it was changed

Because the Algolia api gives useful information but it is turned into a single string by the client. 