### PR TITLE
Feat(scoped-copy-methods): Adds copy_settings, copy_synonyms and copy_rules

### DIFF
--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -831,7 +831,7 @@ module Algolia
   # @param request_options contains extra parameters to send with your query
   #
   def Algolia.copy_settings!(src_index, dst_index, request_options = {})
-    Algolia.client.copy_settings!(src_index, dst_index,request_options)
+    Algolia.client.copy_settings!(src_index, dst_index, request_options)
   end
 
   #
@@ -853,7 +853,7 @@ module Algolia
   # @param request_options contains extra parameters to send with your query
   #
   def Algolia.copy_synonyms!(src_index, dst_index, request_options = {})
-    Algolia.client.copy_synonyms!(src_index, dst_index,request_options)
+    Algolia.client.copy_synonyms!(src_index, dst_index, request_options)
   end
 
   #
@@ -875,7 +875,7 @@ module Algolia
   # @param request_options contains extra parameters to send with your query
   #
   def Algolia.copy_rules!(src_index, dst_index, request_options = {})
-    Algolia.client.copy_rules!(src_index, dst_index,request_options)
+    Algolia.client.copy_rules!(src_index, dst_index, request_options)
   end
 
   #

--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -209,6 +209,78 @@ module Algolia
     end
 
     #
+    # Copy an existing index settings.
+    #
+    # @param src_index the name of index to copy.
+    # @param dst_index the new index name that will contains a copy of srcIndexName's settings (destination's settings will be overriten if it already exist).
+    # @param request_options contains extra parameters to send with your query
+    #
+    def copy_settings(src_index, dst_index, request_options = {})
+      copy_index(src_index, dst_index, ['settings'], request_options)
+    end
+
+    #
+    # Copy an existing index settings and wait until the copy has been processed.
+    #
+    # @param src_index the name of index to copy.
+    # @param dst_index the new index name that will contains a copy of srcIndexName settings (destination settings will be overriten if it already exist).
+    # @param request_options contains extra parameters to send with your query
+    #
+    def copy_settings!(src_index, dst_index, request_options = {})
+      res = copy_settings(src_index, dst_index, request_options)
+      wait_task(dst_index, res['taskID'], WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY, request_options)
+      res
+    end
+
+    #
+    # Copy an existing index synonyms.
+    #
+    # @param src_index the name of index to copy.
+    # @param dst_index the new index name that will contains a copy of srcIndexName's synonyms (destination's synonyms will be overriten if it already exist).
+    # @param request_options contains extra parameters to send with your query
+    #
+    def copy_synonyms(src_index, dst_index, request_options = {})
+      copy_index(src_index, dst_index, ['synonyms'], request_options)
+    end
+
+    #
+    # Copy an existing index synonyms and wait until the copy has been processed.
+    #
+    # @param src_index the name of index to copy.
+    # @param dst_index the new index name that will contains a copy of srcIndexName synonyms (destination synonyms will be overriten if it already exist).
+    # @param request_options contains extra parameters to send with your query
+    #
+    def copy_synonyms!(src_index, dst_index, request_options = {})
+      res = copy_synonyms(src_index, dst_index, request_options)
+      wait_task(dst_index, res['taskID'], WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY, request_options)
+      res
+    end
+
+    #
+    # Copy an existing index rules.
+    #
+    # @param src_index the name of index to copy.
+    # @param dst_index the new index name that will contains a copy of srcIndexName's rules (destination's rules will be overriten if it already exist).
+    # @param request_options contains extra parameters to send with your query
+    #
+    def copy_rules(src_index, dst_index, request_options = {})
+      copy_index(src_index, dst_index, ['rules'], request_options)
+    end
+
+    #
+    # Copy an existing index rules and wait until the copy has been processed.
+    #
+    # @param src_index the name of index to copy.
+    # @param dst_index the new index name that will contains a copy of srcIndexName rules (destination rules will be overriten if it already exist).
+    # @param request_options contains extra parameters to send with your query
+    #
+    def copy_rules!(src_index, dst_index, request_options = {})
+      res = copy_rules(src_index, dst_index, request_options)
+      wait_task(dst_index, res['taskID'], WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY, request_options)
+      res
+    end
+
+    #
     # Delete an index
     # @param name the name of the index to delete
     # @param request_options contains extra parameters to send with your query
@@ -738,6 +810,72 @@ module Algolia
   #
   def Algolia.copy_index!(src_index, dst_index, scope = nil, request_options = {})
     Algolia.client.copy_index!(src_index, dst_index, scope, request_options)
+  end
+
+  #
+  # Copy an existing index settings.
+  #
+  # @param src_index the name of index to copy.
+  # @param dst_index the new index name that will contains a copy of src_index_name settings (destination settings will be overriten if it already exist).
+  # @param request_options contains extra parameters to send with your query
+  #
+  def Algolia.copy_settings(src_index, dst_index, request_options = {})
+    Algolia.client.copy_settings(src_index, dst_index, request_options)
+  end
+
+  #
+  # Copy an existing index settings and wait until the copy has been processed.
+  #
+  # @param src_index the name of index to copy.
+  # @param dst_index the new index name that will contains a copy of src_index_name settings (destination settings will be overriten if it already exist).
+  # @param request_options contains extra parameters to send with your query
+  #
+  def Algolia.copy_settings!(src_index, dst_index, request_options = {})
+    Algolia.client.copy_settings!(src_index, dst_index,request_options)
+  end
+
+  #
+  # Copy an existing index synonyms.
+  #
+  # @param src_index the name of index to copy.
+  # @param dst_index the new index name that will contains a copy of src_index_name synonyms (destination synonyms will be overriten if it already exist).
+  # @param request_options contains extra parameters to send with your query
+  #
+  def Algolia.copy_synonyms(src_index, dst_index, request_options = {})
+    Algolia.client.copy_synonyms(src_index, dst_index, request_options)
+  end
+
+  #
+  # Copy an existing index synonyms and wait until the copy has been processed.
+  #
+  # @param src_index the name of index to copy.
+  # @param dst_index the new index name that will contains a copy of src_index_name synonyms (destination synonyms will be overriten if it already exist).
+  # @param request_options contains extra parameters to send with your query
+  #
+  def Algolia.copy_synonyms!(src_index, dst_index, request_options = {})
+    Algolia.client.copy_synonyms!(src_index, dst_index,request_options)
+  end
+
+  #
+  # Copy an existing index rules.
+  #
+  # @param src_index the name of index to copy.
+  # @param dst_index the new index name that will contains a copy of src_index_name rules (destination rules will be overriten if it already exist).
+  # @param request_options contains extra parameters to send with your query
+  #
+  def Algolia.copy_rules(src_index, dst_index, request_options = {})
+    Algolia.client.copy_rules(src_index, dst_index, request_options)
+  end
+
+  #
+  # Copy an existing index rules and wait until the copy has been processed.
+  #
+  # @param src_index the name of index to copy.
+  # @param dst_index the new index name that will contains a copy of src_index_name rules (destination rules will be overriten if it already exist).
+  # @param request_options contains extra parameters to send with your query
+  #
+  def Algolia.copy_rules!(src_index, dst_index, request_options = {})
+    Algolia.client.copy_rules!(src_index, dst_index,request_options)
   end
 
   #

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -439,8 +439,8 @@ describe 'Client' do
     end
 
     res = @index.set_settings!({
-      'searchableAttributes' => ['one'],
-    })
+                                   'searchableAttributes' => ['one'],
+                               })
 
     @index.wait_task(res['taskID'])
     Algolia.copy_settings!(@index.name, index.name)
@@ -459,7 +459,7 @@ describe 'Client' do
     end
 
     @index.save_synonym!('foo', {
-      :objectID => 'foo', :synonyms => ['car', 'vehicle', 'auto'], :type => 'synonym',
+        :objectID => 'foo', :synonyms => ['car', 'vehicle', 'auto'], :type => 'synonym',
     })
 
     Algolia.copy_synonyms!(@index.name, index.name)
@@ -478,9 +478,9 @@ describe 'Client' do
     end
 
     @index.save_rule!('bar', {
-      :objectID => 'bar',
-      :condition => { :pattern => 'test', :anchoring => 'contains' },
-      :consequence => { :params => { :query => 'this is better' } }
+        :objectID => 'bar',
+        :condition => {:pattern => 'test', :anchoring => 'contains'},
+        :consequence => {:params => {:query => 'this is better'}}
     })
 
     Algolia.copy_rules!(@index.name, index.name)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -430,6 +430,66 @@ describe 'Client' do
     index.delete_index!
   end
 
+  it "should copy only settings" do
+    index = Algolia::Index.new(safe_index_name("àlgol?à"))
+    begin
+      @index.clear_index
+      Algolia.delete_index index.name
+    rescue
+    end
+
+    res = @index.set_settings!({
+      'searchableAttributes' => ['one'],
+    })
+
+    @index.wait_task(res['taskID'])
+    Algolia.copy_settings!(@index.name, index.name)
+    @index.delete_index!
+
+    index.get_settings['searchableAttributes'].should eq(['one'])
+    index.delete_index!
+  end
+
+  it "should copy only synonyms" do
+    index = Algolia::Index.new(safe_index_name("àlgol?à"))
+    begin
+      @index.clear_index
+      Algolia.delete_index index.name
+    rescue
+    end
+
+    @index.save_synonym!('foo', {
+      :objectID => 'foo', :synonyms => ['car', 'vehicle', 'auto'], :type => 'synonym',
+    })
+
+    Algolia.copy_synonyms!(@index.name, index.name)
+    @index.delete_index!
+
+    index.get_synonym('foo')['objectID'].should eq('foo')
+    index.delete_index!
+  end
+
+  it "should copy only rules" do
+    index = Algolia::Index.new(safe_index_name("àlgol?à"))
+    begin
+      @index.clear_index
+      Algolia.delete_index index.name
+    rescue
+    end
+
+    @index.save_rule!('bar', {
+      :objectID => 'bar',
+      :condition => { :pattern => 'test', :anchoring => 'contains' },
+      :consequence => { :params => { :query => 'this is better' } }
+    })
+
+    Algolia.copy_rules!(@index.name, index.name)
+    @index.delete_index!
+
+    index.get_rule('bar')['objectID'].should eq('bar')
+    index.delete_index!
+  end
+
   it "should copy parts of the index only" do
     index = Algolia::Index.new(safe_index_name("àlgol?à"))
     begin


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | yes


## What was changed

This Pull Request adds the methods `copy_settings`, `copy_synonyms` and `copy_rules` into the `Client::class`. Behind the scenes, every new copy method is just performing a `copy_index` with a different `scope` param, example:

```ruby
    def copy_rules(src_index, dst_index, request_options = {})
      copy_index(src_index, dst_index, ['rules'], request_options)
    end
```