### PR TITLE
Feat(replace-all-methods): Adds replace_all_objects, replace_all_rules and replace_all_synonyms

### DIFF
--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -378,9 +378,9 @@ module Algolia
       end
 
       if safe
-        responses.each {|res|
+        responses.each do |res|
           tmp_index.wait_task(res['taskID'], WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY, request_options)
-        }
+        end
       end
 
       res = @client.move_index(tmp_index.name, @name, request_options)

--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -377,6 +377,12 @@ module Algolia
         responses << res
       end
 
+      if safe
+        responses.each {|res|
+          tmp_index.wait_task(res['taskID'], WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY, request_options)
+        }
+      end
+
       res = @client.move_index(tmp_index.name, @name, request_options)
       responses << res
 
@@ -394,13 +400,7 @@ module Algolia
     # @param request_options contains extra parameters to send with your query
     #
     def replace_all_objects!(objects, request_options = {})
-      responses = replace_all_objects(objects, request_options)
-
-      responses.each {|res|
-        wait_task(res['taskID'], WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY, request_options)
-      }
-
-      responses
+      replace_all_objects(objects, {'safe' => true})
     end
 
     #

--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -400,7 +400,7 @@ module Algolia
     # @param request_options contains extra parameters to send with your query
     #
     def replace_all_objects!(objects, request_options = {})
-      replace_all_objects(objects, {'safe' => true})
+      replace_all_objects(objects, request_options.merge(:safe => true))
     end
 
     #

--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -337,7 +337,7 @@ module Algolia
     # Override the current objects by the given array of objects and wait end of indexing. Settings,
     # synonyms and query rules are untouched. The objects are replaced without any downtime.
     #
-    # @param objects the array of objects to save, each object must contain an objectID attribute
+    # @param objects the array of objects to save
     # @param request_options contains extra parameters to send with your query
     #
     def replace_all_objects(objects, request_options = {})
@@ -396,7 +396,7 @@ module Algolia
     #
     # Override the current objects by the given array of objects and wait end of indexing
     #
-    # @param objects the array of objects to save, each object must contain an objectID attribute
+    # @param objects the array of objects to save
     # @param request_options contains extra parameters to send with your query
     #
     def replace_all_objects!(objects, request_options = {})

--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -365,7 +365,7 @@ module Algolia
         batch << object
         count += 1
         if count == batch_size
-          res = tmp_index.save_objects(batch, request_options)
+          res = tmp_index.add_objects(batch, request_options)
           responses << res
           batch = []
           count = 0
@@ -373,7 +373,7 @@ module Algolia
       end
 
       if batch.any?
-        res = tmp_index.save_objects(batch, request_options)
+        res = tmp_index.add_objects(batch, request_options)
         responses << res
       end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -251,11 +251,11 @@ describe 'Client' do
 
   it "should replace all objects" do
     @index.save_objects!([{:objectID => '1'}, {:objectID => '2'}])
-    @index.replace_all_objects!([{:objectID => '3'}, {:objectID => '4'}])
+    @index.replace_all_objects!([{'color' => 'black'}, {:objectID => '4'}])
 
     res = @index.search('')
     res["hits"][0]['objectID'].should eq('4')
-    res["hits"][1]['objectID'].should eq('3')
+    res["hits"][1]['color'].should eq('black')
     res["hits"].length.should eq(2)
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -272,6 +272,10 @@ describe 'Client' do
   end
 
   it "should be thread safe" do
+    @index.clear!
+    @index.add_object!({ :name => "John Doe", :email => "john@doe.org" })
+    @index.add_object!({ :name => "John Doe", :email => "john@doe.org" })
+
     threads = []
     64.times do
       t = Thread.new do


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | yes


## What was changed

This Pull Request adds the methods `replace_all_objects`, `replace_all_rules` and `replace_all_synonyms` into the `Index::class`.