### PR TITLE
Add insights.rb to gemspec

### DIFF
--- a/algoliasearch.gemspec
+++ b/algoliasearch.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |s|
     "lib/algolia/client.rb",
     "lib/algolia/error.rb",
     "lib/algolia/index.rb",
+    "lib/algolia/insights.rb",
     "lib/algolia/protocol.rb",
     "lib/algolia/version.rb",
     "lib/algolia/webmock.rb",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #330
| Need Doc update   | no

## Describe your change

Make sure `insights` is part of the gemspec

## What problem is this fixing?

Users currently importing the lib have an error because a file is missing from the release

@julienbourdeau you'll still need to do a RubyGems release after merging
