### PR TITLE
Add restore_api_key method

### DIFF
--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -456,6 +456,13 @@ module Algolia
     end
 
     #
+    # Restore a deleted api key
+    #
+    def restore_api_key(key, request_options = {})
+      post(Protocol.restore_key_uri(key), :write, request_options)
+    end
+
+    #
     # Send a batch request targeting multiple indices
     #
     def batch(operations, request_options = {})
@@ -1043,6 +1050,13 @@ module Algolia
   #
   def Algolia.delete_api_key(key, request_options = {})
     Algolia.client.delete_api_key(key, request_options)
+  end
+
+  #
+  # Restore an existing api key
+  #
+  def Algolia.restore_api_key(key, request_options = {})
+    Algolia.client.restore_api_key(key, request_options)
   end
 
   #

--- a/lib/algolia/protocol.rb
+++ b/lib/algolia/protocol.rb
@@ -109,6 +109,10 @@ module Algolia
       "/#{VERSION}/keys/#{key}"
     end
 
+    def Protocol.restore_key_uri(key)
+      "/#{VERSION}/keys/#{key}/restore"
+    end
+
     def Protocol.index_key_uri(index, key)
       "#{index_uri(index)}/keys/#{key}"
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -83,6 +83,7 @@ describe 'API keys', :maintainers_only => true do
 
   it "should test index keys" do
     @index.set_settings!({}) # ensure the index exists
+
     resIndex = @index.list_api_keys
     newIndexKey = @index.add_api_key(['search'])
     newIndexKey['key'].should_not eq("")
@@ -124,6 +125,15 @@ describe 'API keys', :maintainers_only => true do
     wait_global_key_missing(newKey['key'])
     resEnd = Algolia.list_api_keys
     is_include(resEnd['keys'], 'value', newKey['key']).should eq(false)
+
+    # Restore the deleted key
+    Algolia.restore_api_key(newKey['key'])
+    wait_global_key(newKey['key'])
+    key_end = Algolia.list_api_keys
+    is_include(key_end['keys'], 'value', newKey['key']).should eq(true)
+
+    # Re-delete the key
+    Algolia.delete_api_key(newKey['key'])
   end
 
   it "Check add keys" do


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | yes


## Describe your change

Algolia API introduced a new endpoint to restore a deleted API key 🎉 

```ruby
Algolia.restore_api_key(the_deleted_key, request_options)
```
