### PR TITLE
Adds sweet top keywords feature

### DIFF
--- a/lib/algolia/analytics.rb
+++ b/lib/algolia/analytics.rb
@@ -44,6 +44,10 @@ module Algolia
       @client.wait_task(index_name, taskID, time_before_retry, request_options)
     end
 
+    def top_searches(index)
+      perform_request(:GET, Protocol.searches_uri, index: index)
+    end
+
     private
 
     def perform_request(method, url, params = {}, data = {})

--- a/lib/algolia/protocol.rb
+++ b/lib/algolia/protocol.rb
@@ -207,5 +207,9 @@ module Algolia
       "/2/abtests/#{ab_test}/stop"
     end
 
+    def Protocol.searches_uri
+      "/2/searches"
+    end
+
   end
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | maybe


## Describe your change
You have this endpoint (https://www.algolia.com/doc/rest-api/analytics/#get-top-searches) that is sweet AF for getting top keywords, but I couldn't find the associated method in the ruby code, so I added it.

## What problem is this fixing?
Gets you closer to achieving client parity with your actual REST API for analytics.