### PR TITLE
Modify WebMock sample to testable with rails

### DIFF
--- a/lib/algolia/webmock.rb
+++ b/lib/algolia/webmock.rb
@@ -11,7 +11,7 @@ module Algolia
       # list indexes
       ::WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes/).to_return(:body => '{ "items": [] }')
       # query index
-      ::WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "hits": [ { "objectID": 42 } ], "page": 1, "hitsPerPage": 1, "nbHits": 1, "nbPages": 1 }')
+      ::WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "hits": [ { "onbjectID": 41 }, { "objectID": 42 } ], "page": 1, "hitsPerPage": 1, "nbHits": 2, "nbPages": 2 }')
       # delete index
       ::WebMock.stub_request(:delete, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "taskID": 42 }')
       # clear index
@@ -46,7 +46,7 @@ module Algolia
       ::WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/keys\/[^\/]+/).to_return(:body => '{ }')
       ::WebMock.stub_request(:delete, /.*\.algolia(net\.com|\.net)\/1\/keys\/[^\/]+/).to_return(:body => '{ }')
       # query POST
-      ::WebMock.stub_request(:post, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+\/query/).to_return(:body => '{ "hits": [ { "objectID": 42 } ], "page": 1, "hitsPerPage": 1, "nbHits": 1, "nbPages": 1 }')
+      ::WebMock.stub_request(:post, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+\/query/).to_return(:body => '{ "hits": [ { "objectID": 41 }, { "objectID": 42 } ], "page": 1, "hitsPerPage": 1, "nbHits": 2, "nbPages": 2 }')
     end
   end
 end

--- a/lib/algolia/webmock.rb
+++ b/lib/algolia/webmock.rb
@@ -11,7 +11,7 @@ module Algolia
       # list indexes
       ::WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes/).to_return(:body => '{ "items": [] }')
       # query index
-      ::WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "hits": [ { "onbjectID": 41 }, { "objectID": 42 } ], "page": 1, "hitsPerPage": 1, "nbHits": 2, "nbPages": 2 }')
+      ::WebMock.stub_request(:get, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "hits": [ { "objectID": 41 }, { "objectID": 42 } ], "page": 1, "hitsPerPage": 1, "nbHits": 2, "nbPages": 2 }')
       # delete index
       ::WebMock.stub_request(:delete, /.*\.algolia(net\.com|\.net)\/1\/indexes\/[^\/]+/).to_return(:body => '{ "taskID": 42 }')
       # clear index

--- a/spec/mock_spec.rb
+++ b/spec/mock_spec.rb
@@ -16,7 +16,7 @@ describe 'With a mocked client' do
   it "should add a simple object" do
     index = Algolia::Index.new("friends")
     index.add_object!({ :name => "John Doe", :email => "john@doe.org" })
-    index.search('').should == { "hits" => [ { "objectID" => 42 } ], "page" => 1, "hitsPerPage" => 1, "nbHits"=>1, "nbPages"=>1 } # mocked
+    index.search('').should == { "hits" => [ { "objectID" => 41 }, { "objectID" => 42 } ], "page" => 1, "hitsPerPage" => 1, "nbHits"=>2, "nbPages"=>2 } # mocked
     index.list_api_keys
     index.browse
     index.clear


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | yes ( https://www.algolia.com/doc/api-client/guides/ruby/webmock/ ) 

## Describe your change

Update response params about pagination, for testing rails code that include algoliasearch-rails gem.
Modify to include one entry on the page.

Otherwise `page: 0` is useful, maybe.

## What problem is this fixing?

Currently, Model's `algolia_search` method (*1) return empty list (*2).
This response is a little inconvenient for testing search.
This change will become to entry present test assertable.

Yes, I know this file is webmock SAMPLE, this PR priority very low...

(*1) `algolia_search` method is defined in algoliasearch-rails gem.
(*2) The empty list is created via Kaminari::PaginatableArray with only 1 value and page param is 1 (not 0).