### PR TITLE
fix(search_user_ids): rename parameter clusterName

### DIFF
--- a/algoliasearch.gemspec
+++ b/algoliasearch.gemspec
@@ -64,8 +64,13 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.9.3')
+        s.add_runtime_dependency     'json',       '>= 1.5.1', '< 2.3'
+      else
+        s.add_runtime_dependency     'json',       '>= 1.5.1'
+      end
+
       s.add_runtime_dependency     'httpclient', '~> 2.8', '>= 2.8.3'
-      s.add_runtime_dependency     'json',       '>= 1.5.1', '< 2.3'
       s.add_development_dependency 'travis',     '~> 0'
       s.add_development_dependency 'rake',       '~> 0'
       s.add_development_dependency 'rdoc',       '~> 0'

--- a/algoliasearch.gemspec
+++ b/algoliasearch.gemspec
@@ -65,16 +65,16 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency     'httpclient', '~> 2.8', '>= 2.8.3'
-      s.add_runtime_dependency     'json',       '>= 1.5.1'
+      s.add_runtime_dependency     'json',       '>= 1.5.1', '< 2.3'
       s.add_development_dependency 'travis',     '~> 0'
       s.add_development_dependency 'rake',       '~> 0'
       s.add_development_dependency 'rdoc',       '~> 0'
     else
       s.add_dependency             'httpclient', '~> 2.8', '>= 2.8.3'
-      s.add_dependency             'json',       '>= 1.5.1'
+      s.add_dependency             'json',       '>= 1.5.1', '< 2.3'
     end
   else
     s.add_dependency               'httpclient', '~> 2.8', '>= 2.8.3'
-    s.add_dependency               'json',       '>= 1.5.1'
+    s.add_dependency               'json',       '>= 1.5.1', '< 2.3'
   end
 end

--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -552,7 +552,7 @@ module Algolia
 
     def search_user_id(query, cluster_name = nil, page = nil, hits_per_page = nil, request_options = {})
       body = { :query => query }
-      body[:clusterName] = cluster_name unless cluster_name.nil?
+      body[:cluster] = cluster_name unless cluster_name.nil?
       body[:page] = page unless page.nil?
       body[:hitsPerPage] = hits_per_page unless hits_per_page.nil?
       post(Protocol.search_user_id_uri, body.to_json, :read, request_options)

--- a/spec/client_mcm_spec.rb
+++ b/spec/client_mcm_spec.rb
@@ -72,6 +72,14 @@ describe 'Multi Cluster Management', :mcm => true do
     item["clusterName"].should eq(@cluster_name)
   end
 
+  it "should find a user_id in a specific cluster" do
+    res = @client.search_user_id(@user_id, @cluster_name, 0, 22)
+    res["hitsPerPage"].should eq(22)
+    item = res["hits"][0]
+    item["userID"].should eq(@user_id)
+    item["clusterName"].should eq(@cluster_name)
+  end
+
   it "should remove a user_id" do
     res = auto_retry do
       @client.remove_user_id(@user_id)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #368
| Need Doc update   | yes


## Describe your change

The method `search_user_id` expected an optional parameter `clusterName`. Actually, the expected parameter is `cluster`