### PR TITLE
chore(gemspec): block json dep for older ruby versions

### DIFF
--- a/algoliasearch.gemspec
+++ b/algoliasearch.gemspec
@@ -64,17 +64,21 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      if defined?(RUBY_VERSION) && RUBY_VERSION < '2.0'
+        s.add_runtime_dependency     'json',       '>= 1.5.1', '< 2.3'
+      else
+        s.add_runtime_dependency     'json',       '>= 1.5.1'
+      end
       s.add_runtime_dependency     'httpclient', '~> 2.8', '>= 2.8.3'
-      s.add_runtime_dependency     'json',       '>= 1.5.1'
       s.add_development_dependency 'travis',     '~> 0'
       s.add_development_dependency 'rake',       '~> 0'
       s.add_development_dependency 'rdoc',       '~> 0'
     else
       s.add_dependency             'httpclient', '~> 2.8', '>= 2.8.3'
-      s.add_dependency             'json',       '>= 1.5.1'
+      s.add_dependency             'json',       '>= 1.5.1', '< 2.3'
     end
   else
     s.add_dependency               'httpclient', '~> 2.8', '>= 2.8.3'
-    s.add_dependency               'json',       '>= 1.5.1'
+    s.add_dependency               'json',       '>= 1.5.1', '< 2.3'
   end
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     


## Describe your change

Block json dependencie for older Ruby version as json 2.3.0 is out and is not compatible with Ruby <= 1.9.3