### PR TITLE
Fix/cluster option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased
+
+**Fixed**
+
+* In `search_user_id`, retrieve param `cluster` instead of `clusterName`. [368](https://github.com/algolia/algoliasearch-client-ruby/issues/368)
+
 ## [1.27.1](https://github.com/algolia/algoliasearch-client-ruby/compare/1.27.0...1.27.1) (2019-09-26)
 
 **Fixed**

--- a/lib/algolia/client.rb
+++ b/lib/algolia/client.rb
@@ -552,7 +552,7 @@ module Algolia
 
     def search_user_id(query, cluster_name = nil, page = nil, hits_per_page = nil, request_options = {})
       body = { :query => query }
-      body[:clusterName] = cluster_name unless cluster_name.nil?
+      body[:cluster] = cluster_name unless cluster_name.nil?
       body[:page] = page unless page.nil?
       body[:hitsPerPage] = hits_per_page unless hits_per_page.nil?
       post(Protocol.search_user_id_uri, body.to_json, :read, request_options)

--- a/spec/client_mcm_spec.rb
+++ b/spec/client_mcm_spec.rb
@@ -72,6 +72,14 @@ describe 'Multi Cluster Management', :mcm => true do
     item["clusterName"].should eq(@cluster_name)
   end
 
+  it "should find a user_id in a specific cluster" do
+    res = @client.search_user_id(@user_id, @cluster_name, 0, 22)
+    res["hitsPerPage"].should eq(22)
+    item = res["hits"][0]
+    item["userID"].should eq(@user_id)
+    item["clusterName"].should eq(@cluster_name)
+  end
+
   it "should remove a user_id" do
     res = auto_retry do
       @client.remove_user_id(@user_id)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #368 
| Need Doc update   | no


## What problem is this fixing?

The method `search_user_id` was wrongly retrieving the `clusterName` parameter instead of `cluster`