### PR TITLE
fix(account-client): retrieve all objects from source index

### DIFF
--- a/lib/algolia/account_client.rb
+++ b/lib/algolia/account_client.rb
@@ -55,7 +55,7 @@ module Algolia
         batch_size = 1000
         count = 0
 
-        source_index.browse()['hits'].each do |obj|
+        source_index.browse do |obj|
           batch << obj
           count += 1
 

--- a/spec/account_client_spec.rb
+++ b/spec/account_client_spec.rb
@@ -47,9 +47,7 @@ describe 'Account client' do
 
   it 'should perform a cross app copy index and assert that destination must not exist' do
 
-    @index_1.save_objects! ([
-        {:objectID => 'one'},
-    ])
+    @index_1.save_objects!(1.upto(1500).map { |i| { :objectID => i, :i => i } })
 
     @index_1.batch_rules! ([
         {
@@ -67,9 +65,9 @@ describe 'Account client' do
 
     Algolia::AccountClient.copy_index!(@index_1, @index_3)
 
-    res = @index_3.search('');
-    res['nbHits'].should eq(1)
-    res['hits'][0]['objectID'].should eq('one')
+    res = @index_3.search('')
+    res['nbHits'].should eq(1500)
+    res['hits'][0]['objectID'].should eq('999')
 
     res = @index_3.search_rules('')['hits']
     res.size.should eq(1)

--- a/spec/account_client_spec.rb
+++ b/spec/account_client_spec.rb
@@ -67,7 +67,6 @@ describe 'Account client' do
 
     res = @index_3.search('')
     res['nbHits'].should eq(1500)
-    res['hits'][0]['objectID'].should eq('999')
 
     res = @index_3.search_rules('')['hits']
     res.size.should eq(1)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #398
| Need Doc update   | no


## Describe your change

There was a bug preventing the fetching of all the objects from the source index. Instead, it retrieved only the first 1000 as it's the default number of hits per page. This commit fixes it
