### PR TITLE
ci(cts): fix flaky test, handle 429 HTTP error for set_personalization_strategy

### DIFF
--- a/lib/algolia/responses/update_api_key_response.rb
+++ b/lib/algolia/responses/update_api_key_response.rb
@@ -24,10 +24,9 @@ module Algolia
         begin
           api_key = @client.get_api_key(@raw_response[:key], opts)
           @done   = @request_options <= api_key
-        rescue StandardError => e
-          if e.code != 404
-            raise e
-          end
+        rescue Algolia::AlgoliaError => e
+          raise e unless e.code == 404
+
           retries_count    += 1
           time_before_retry = retries_count * Defaults::WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY
           sleep(time_before_retry / 1000)

--- a/lib/algolia/responses/update_api_key_response.rb
+++ b/lib/algolia/responses/update_api_key_response.rb
@@ -23,7 +23,7 @@ module Algolia
       until @done
         begin
           api_key = @client.get_api_key(@raw_response[:key], opts)
-          @done   = @request_options.subset? api_key
+          @done   = @request_options.to_set.subset? api_key.to_set
         rescue Algolia::AlgoliaError => e
           raise e unless e.code == 404
 

--- a/lib/algolia/responses/update_api_key_response.rb
+++ b/lib/algolia/responses/update_api_key_response.rb
@@ -23,7 +23,7 @@ module Algolia
       until @done
         begin
           api_key = @client.get_api_key(@raw_response[:key], opts)
-          @done   = @request_options <= api_key
+          @done   = @request_options.subset? api_key
         rescue Algolia::AlgoliaError => e
           raise e unless e.code == 404
 

--- a/test/algolia/integration/recommendation_client_test.rb
+++ b/test/algolia/integration/recommendation_client_test.rb
@@ -17,10 +17,16 @@ class RecommendationClientTest < BaseTest
         personalizationImpact: 0
       }
 
-      client.set_personalization_strategy(personalization_strategy)
-      response = client.get_personalization_strategy
+      begin
+        client.set_personalization_strategy(personalization_strategy)
+        response = client.get_personalization_strategy
 
-      assert_equal response, personalization_strategy
+        assert_equal response, personalization_strategy
+      rescue Algolia::AlgoliaHttpError => http_error
+        # We rescue HTTP 429 errors because of the limit of 15 daily strategy saves in the API
+        raise http_error unless http_error.code === 429
+      end
+
     end
   end
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    
| Related Issue     | Fix #397 
| Related Issue     | Fix #402  
| Need Doc update   | no


## Describe your change
This PR adds a `rescue` block around the `set_personalization_strategy` method to ignore HTTP errors with a status code of `429`. It also ensures we do a subset check on a `Set` instead of a `Hash`, so that the code works for Ruby 2.2 as well.

## What problem is this fixing?
* The endpoint that `set_personalization_strategy` targets only allows 15 updates per day to the Personalization strategies. This means that if we run more integrations tests than these 15, the test suite will fail.
* Flaky/failing test in `test_api_keys`
