### PR TITLE
feat(find_objects): use lambda instead of block

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,8 +110,8 @@ workflows:
       - test_ruby:
           matrix:
             parameters:
-              version: ['2.2', '2.3', '2.4', '2.5', '2.6', 'latest']
+              version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7']
       - test_jruby:
           matrix:
             parameters:
-              version: ['9', '9.1', '9.2', 'latest']
+              version: ['9.1', '9.2']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,6 @@ aliases:
        mkdir /tmp/test-results
        bundle exec rake test:all
 
-  - &store_test_results
-    path: /tmp/test-results
-
-  - &store_artifacts
-    path: /tmp/test-results
-    destination: test-results
-
 references:
   default_docker_ruby_executor: &default_docker_ruby_executor
     image: circleci/ruby:<< parameters.version >>
@@ -81,8 +74,6 @@ jobs:
       - run: *install_bundler
       - save_cache: *save_cache
       - run: *run_tests
-      - store_test_results: *store_test_results
-      - store_artifacts: *store_artifacts
 
   test_jruby:
     description: Build, unit and integration tests for JRuby
@@ -98,8 +89,6 @@ jobs:
       - run: *install_bundler
       - save_cache: *save_cache
       - run: *run_tests
-      - store_test_results: *store_test_results
-      - store_artifacts: *store_artifacts
 
   release:
     description: Release a new version of the Ruby client

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,7 @@ aliases:
 
   - &run_lint
     name: Run linting tool
-    command: |
-      if [ << parameters.version >> -eq '2.6' || 'latest' ]
-      then
-        bundle exec rake rubocop
-      fi
+    command: bundle exec rake rubocop
 
   - &run_tests
      name: Run unit and integration tests
@@ -58,6 +54,19 @@ references:
 version: 2.1
 
 jobs:
+  format:
+    description: Run our linter checks against the entire code base
+    parameters:
+      version:
+        type: string
+    docker:
+      - *default_docker_ruby_executor
+    steps:
+      - checkout
+      - run: *check_bundler
+      - run: *install_bundler
+      - run: *run_lint
+
   test_ruby:
     description: Build, unit and integration tests for Ruby
     parameters:
@@ -71,7 +80,6 @@ jobs:
       - restore_cache: *restore_cache
       - run: *install_bundler
       - save_cache: *save_cache
-      - run: *run_lint
       - run: *run_tests
       - store_test_results: *store_test_results
       - store_artifacts: *store_artifacts
@@ -89,7 +97,6 @@ jobs:
       - restore_cache: *restore_cache
       - run: *install_bundler
       - save_cache: *save_cache
-      - run: *run_lint
       - run: *run_tests
       - store_test_results: *store_test_results
       - store_artifacts: *store_artifacts
@@ -98,6 +105,8 @@ workflows:
   version: 2
   ci:
     jobs:
+      - format:
+          version: '2.7'
       - test_ruby:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,26 @@ jobs:
       - store_test_results: *store_test_results
       - store_artifacts: *store_artifacts
 
+  release:
+    description: Release a new version of the Ruby client
+    parameters:
+      version:
+        type: string
+    docker:
+      - *default_docker_ruby_executor
+    steps:
+      - checkout
+      - run: *check_bundler
+      - run: *install_bundler
+      - run:
+          name: Build new gem
+          command: gem build algolia.gemspec
+      - run:
+          name: Publish new gem
+          command: |
+            if [[ -z "$RUBYGEMS_API_KEY" ]]; then echo '$RUBYGEMS_API_KEY is not set'; exit 1; fi
+            gem push --key $RUBYGEMS_API_KEY $(ls algolia-*.gem)
+
 workflows:
   version: 2
   ci:
@@ -115,3 +135,14 @@ workflows:
           matrix:
             parameters:
               version: ['9.1', '9.2']
+      - release:
+          version: '2.7'
+          requires:
+            - format
+            - test_ruby
+            - test_jruby
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^[1-9]+.[0-9]+.[0-9]+.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,14 +127,23 @@ workflows:
     jobs:
       - format:
           version: '2.7'
+          filters:
+            tags:
+              only: /.*/
       - test_ruby:
           matrix:
             parameters:
               version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7']
+          filters:
+            tags:
+              only: /.*/
       - test_jruby:
           matrix:
             parameters:
               version: ['9.1', '9.2']
+          filters:
+            tags:
+              only: /.*/
       - release:
           version: '2.7'
           requires:
@@ -143,6 +152,6 @@ workflows:
             - test_jruby
           filters:
             branches:
-              only: master
+              ignore: /.*/
             tags:
               only: /^[1-9]+.[0-9]+.[0-9]+.*/

--- a/Rakefile
+++ b/Rakefile
@@ -18,12 +18,16 @@ namespace :test do
     t.libs << 'test'
     t.libs << 'lib'
     t.test_files = FileList['test/algolia/unit/**/*_test.rb']
+    t.verbose    = true
+    t.warning    = false
   end
 
   Rake::TestTask.new(:integration) do |t|
     t.libs << 'test'
     t.libs << 'lib'
     t.test_files = FileList['test/algolia/integration/**/*_test.rb']
+    t.verbose    = true
+    t.warning    = false
   end
 
   desc 'Run unit and integration tests'

--- a/lib/algolia/helpers.rb
+++ b/lib/algolia/helpers.rb
@@ -72,4 +72,12 @@ module Helpers
   def self.included(base)
     base.extend(Helpers)
   end
+
+  def hash_includes_subset?(hash, subset)
+    res = true
+    subset.each do |k, v|
+      res &&= hash[k] == v
+    end
+    res
+  end
 end

--- a/lib/algolia/responses/add_api_key_response.rb
+++ b/lib/algolia/responses/add_api_key_response.rb
@@ -22,7 +22,7 @@ module Algolia
         begin
           @client.get_api_key(@raw_response[:key], opts)
           @done = true
-        rescue StandardError => e
+        rescue AlgoliaError => e
           if e.code != 404
             raise e
           end

--- a/lib/algolia/responses/delete_api_key_response.rb
+++ b/lib/algolia/responses/delete_api_key_response.rb
@@ -23,7 +23,7 @@ module Algolia
       until @done
         begin
           @client.get_api_key(@key, opts)
-        rescue StandardError => e
+        rescue AlgoliaError => e
           @done = e.code == 404
 
           unless @done

--- a/lib/algolia/responses/restore_api_key_response.rb
+++ b/lib/algolia/responses/restore_api_key_response.rb
@@ -20,7 +20,7 @@ module Algolia
         begin
           @client.get_api_key(@key, opts)
           @done = true
-        rescue StandardError => e
+        rescue AlgoliaError => e
           if e.code != 404
             raise e
           end

--- a/lib/algolia/responses/update_api_key_response.rb
+++ b/lib/algolia/responses/update_api_key_response.rb
@@ -25,9 +25,7 @@ module Algolia
           api_key = @client.get_api_key(@raw_response[:key], opts)
           @done   = @request_options <= api_key
         rescue AlgoliaError => e
-          if e.code != 404
-            raise e
-          end
+          raise e unless e.code == 404
           retries_count    += 1
           time_before_retry = retries_count * Defaults::WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY
           sleep(time_before_retry / 1000)

--- a/lib/algolia/responses/update_api_key_response.rb
+++ b/lib/algolia/responses/update_api_key_response.rb
@@ -1,5 +1,6 @@
 module Algolia
   class UpdateApiKeyResponse < BaseResponse
+    include Helpers
     attr_reader :raw_response
 
     # @param client [Search::Client] Algolia Search Client used for verification
@@ -23,7 +24,7 @@ module Algolia
       until @done
         begin
           api_key = @client.get_api_key(@raw_response[:key], opts)
-          @done   = @request_options <= api_key
+          @done   = hash_includes_subset?(api_key, @request_options)
         rescue AlgoliaError => e
           raise e unless e.code == 404
           retries_count    += 1

--- a/lib/algolia/responses/update_api_key_response.rb
+++ b/lib/algolia/responses/update_api_key_response.rb
@@ -24,7 +24,7 @@ module Algolia
         begin
           api_key = @client.get_api_key(@raw_response[:key], opts)
           @done   = @request_options <= api_key
-        rescue StandardError => e
+        rescue AlgoliaError => e
           if e.code != 404
             raise e
           end

--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -112,11 +112,11 @@ module Algolia
         paginate        = true
         page            = 0
 
-        query = request_options.delete(:query) || ''
+        query    = request_options.delete(:query) || ''
         paginate = request_options.delete(:paginate) if request_options.has_key?(:paginate)
 
         has_next_page = true
-        while has_next_page do
+        while has_next_page
           request_options[:page] = page
           res                    = search(query, request_options)
 

--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -107,7 +107,6 @@ module Algolia
       #
       # @return [Hash|AlgoliaHttpError] the matching object and its position in the result set
       #
-      # TODO: use lambda
       def find_object(callback, opts = {})
         request_options = symbolize_hash(opts)
         paginate        = true

--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -131,7 +131,7 @@ module Algolia
           end
 
           has_next_page = page + 1 < res[:nbPages]
-          raise AlgoliaHttpError.new(404, 'Object not found') unless paginate || has_next_page
+          raise AlgoliaHttpError.new(404, 'Object not found') unless paginate && has_next_page
 
           page += 1
         end

--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -102,45 +102,37 @@ module Algolia
       # Usage example:
       #  index.find_object({'query' => '', 'paginate' => true}) {|obj| obj.key?('company') and obj['company'] == 'Apple'}
       #
+      # @param callback [Lambda] contains extra parameters to send with your query
       # @param opts [Hash] contains extra parameters to send with your query
       #
       # @return [Hash|AlgoliaHttpError] the matching object and its position in the result set
       #
       # TODO: use lambda
-      def find_object(opts = {})
+      def find_object(callback, opts = {})
         request_options = symbolize_hash(opts)
         paginate        = true
         page            = 0
 
-        query = request_options[:query] || ''
-        request_options.delete(:query)
+        query = request_options.delete(:query) || ''
+        paginate = request_options.delete(:paginate) if request_options.has_key?(:paginate)
 
-        if request_options.has_key? :paginate
-          paginate = request_options[:paginate]
-        end
-
-        request_options.delete(:paginate)
-
-        loop do
+        has_next_page = true
+        while has_next_page do
           request_options[:page] = page
           res                    = search(query, request_options)
 
-          if block_given?
-            res[:hits].each_with_index do |hit, i|
-              if yield(hit)
-                return {
-                  object: hit,
-                  position: i,
-                  page: page
-                }
-              end
+          res[:hits].each_with_index do |hit, i|
+            if callback.call(hit)
+              return {
+                object: hit,
+                position: i,
+                page: page
+              }
             end
           end
 
           has_next_page = page + 1 < res[:nbPages]
-          if !paginate || !has_next_page
-            raise AlgoliaHttpError.new(404, 'Object not found')
-          end
+          raise AlgoliaHttpError.new(404, 'Object not found') unless paginate || has_next_page
 
           page += 1
         end

--- a/test/algolia/integration/recommendation_client_test.rb
+++ b/test/algolia/integration/recommendation_client_test.rb
@@ -17,7 +17,11 @@ class RecommendationClientTest < BaseTest
         personalizationImpact: 0
       }
 
-      client.set_personalization_strategy(personalization_strategy)
+      begin
+        client.set_personalization_strategy(personalization_strategy)
+      rescue Algolia::AlgoliaHttpError => e
+        raise e unless e.code == 429
+      end
       response = client.get_personalization_strategy
 
       assert_equal response, personalization_strategy

--- a/test/algolia/integration/search_index_test.rb
+++ b/test/algolia/integration/search_index_test.rb
@@ -296,40 +296,32 @@ class SearchIndexTest < BaseTest
 
     def test_find_objects
       exception = assert_raises Algolia::AlgoliaHttpError do
-        @index.find_object({ query: '', paginate: false })
+        @index.find_object(lambda {|hit| false }, { query: '', paginate: false })
       end
 
       assert_equal 'Object not found', exception.message
 
-      exception = assert_raises Algolia::AlgoliaHttpError do
-        @index.find_object({ query: '', paginate: false }) { false }
-      end
-
-      assert_equal 'Object not found', exception.message
-
-      response = @index.find_object({ query: '', paginate: false }) { true }
+      response = @index.find_object(lambda {|hit| true }, { query: '', paginate: false })
       assert_equal 0, response[:position]
       assert_equal 0, response[:page]
 
-      # we use a lambda and convert it to a block with `&`
-      # so as not to repeat the condition
       condition = -> (obj) do
         obj.has_key?(:company) && obj[:company] == 'Apple'
       end
 
       exception = assert_raises Algolia::AlgoliaHttpError do
-        @index.find_object({ query: 'algolia', paginate: false }, &condition)
+        @index.find_object(condition, { query: 'algolia', paginate: false })
       end
 
       assert_equal 'Object not found', exception.message
 
       exception = assert_raises Algolia::AlgoliaHttpError do
-        @index.find_object({ query: '', paginate: false, hitsPerPage: 5 }, &condition)
+        @index.find_object(condition, { query: '', paginate: false, hitsPerPage: 5 })
       end
 
       assert_equal 'Object not found', exception.message
 
-      response = @index.find_object({ query: '', paginate: true, hitsPerPage: 5 }, &condition)
+      response = @index.find_object(condition, { query: '', paginate: true, hitsPerPage: 5 })
       assert_equal 0, response[:position]
       assert_equal 2, response[:page]
 

--- a/test/algolia/integration/search_index_test.rb
+++ b/test/algolia/integration/search_index_test.rb
@@ -296,12 +296,12 @@ class SearchIndexTest < BaseTest
 
     def test_find_objects
       exception = assert_raises Algolia::AlgoliaHttpError do
-        @index.find_object(lambda {|hit| false }, { query: '', paginate: false })
+        @index.find_object(-> (_hit) { false }, { query: '', paginate: false })
       end
 
       assert_equal 'Object not found', exception.message
 
-      response = @index.find_object(lambda {|hit| true }, { query: '', paginate: false })
+      response = @index.find_object(-> (_hit) { true }, { query: '', paginate: false })
       assert_equal 0, response[:position]
       assert_equal 0, response[:page]
 

--- a/test/algolia/unit/helpers_test.rb
+++ b/test/algolia/unit/helpers_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 
 class HelpersTest
   include Helpers
+
   describe 'test helpers' do
     def test_deserialize_settings
       old_settings = {
@@ -19,6 +20,50 @@ class HelpersTest
 
       deserialized_settings = deserialize_settings(old_settings)
       assert_equal new_settings, deserialized_settings
+    end
+  end
+
+  describe 'test hash_includes_subset' do
+    def test_empty_hashes
+      h      = {}
+      subset = {}
+      assert hash_includes_subset?(h, subset)
+    end
+
+    def test_with_empty_subset
+      h      = { a: 100, b: 200 }
+      subset = {}
+      assert hash_includes_subset?(h, subset)
+    end
+
+    def test_subset_included
+      h      = { a: 100, b: 200 }
+      subset = { a: 100 }
+      assert hash_includes_subset?(h, subset)
+    end
+
+    def test_subset_not_included
+      h      = { a: 100, b: 200 }
+      subset = { c: 300 }
+      refute hash_includes_subset?(h, subset)
+    end
+
+    def test_subset_included_but_wrong_value
+      h      = { a: 100, b: 200 }
+      subset = { a: 200 }
+      refute hash_includes_subset?(h, subset)
+    end
+
+    def test_subset_included_with_multiple_values
+      h      = { a: 100, b: 200, c: 300 }
+      subset = { a: 100, b: 200 }
+      assert hash_includes_subset?(h, subset)
+    end
+
+    def test_subset_not_included_because_too_many_values
+      h      = { a: 100, b: 200 }
+      subset = { a: 100, b: 200, c: 300 }
+      refute hash_includes_subset?(h, subset)
     end
   end
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #407 

## Describe your change
This PR introduces the use of lambda's in the `find_object` method instead of using blocks.
