### PR TITLE
fix(config): changes default_headers to headers

### DIFF
--- a/lib/algolia/config/algolia_config.rb
+++ b/lib/algolia/config/algolia_config.rb
@@ -3,7 +3,7 @@ require 'faraday'
 module Algolia
   # Class AlgoliaConfig
   class AlgoliaConfig
-    attr_accessor :app_id, :api_key, :default_headers, :batch_size, :read_timeout, :write_timeout, :connect_timeout, :compression_type,
+    attr_accessor :app_id, :api_key, :headers, :batch_size, :read_timeout, :write_timeout, :connect_timeout, :compression_type,
                   :symbolize_keys
 
     #
@@ -22,7 +22,7 @@ module Algolia
       @app_id  = opts[:app_id]
       @api_key = opts[:api_key]
 
-      @default_headers = {
+      @headers = {
         Defaults::HEADER_API_KEY => @api_key,
         Defaults::HEADER_APP_ID => @app_id,
         'Content-Type' => 'application/json; charset=utf-8',

--- a/lib/algolia/transport/transport.rb
+++ b/lib/algolia/transport/transport.rb
@@ -132,10 +132,10 @@ module Algolia
       # @return [Hash] merged headers
       #
       def generate_headers(request_options = {})
-        headers                                                     = {}
-        extra_headers                                               = request_options.headers || {}
-        @config.default_headers.each { |key, val| headers[key.to_s] = val }
-        extra_headers.each { |key, val| headers[key.to_s]           = val }
+        headers                                             = {}
+        extra_headers                                       = request_options.headers || {}
+        @config.headers.each { |key, val| headers[key.to_s] = val }
+        extra_headers.each { |key, val| headers[key.to_s]   = val }
         if request_options.compression_type == Defaults::GZIP_ENCODING
           headers['Accept-Encoding']  = Defaults::GZIP_ENCODING
         end

--- a/sig/config/algolia_config.rbs
+++ b/sig/config/algolia_config.rbs
@@ -5,7 +5,7 @@ module Algolia
 
     attr_accessor api_key: String
 
-    attr_accessor default_headers: Hash[String, String]
+    attr_accessor headers: Hash[String, String]
 
     attr_accessor batch_size: Integer
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     

Rename `default_headers` to `headers`