### PR TITLE
fix(config): rename app_id to application_id

### DIFF
--- a/lib/algolia/analytics_client.rb
+++ b/lib/algolia/analytics_client.rb
@@ -26,7 +26,7 @@ module Algolia
       # @return self
       #
       def self.create(app_id, api_key)
-        config = Analytics::Config.new(app_id: app_id, api_key: api_key)
+        config = Analytics::Config.new(application_id: app_id, api_key: api_key)
         create_with_config(config)
       end
 

--- a/lib/algolia/config/analytics_config.rb
+++ b/lib/algolia/config/analytics_config.rb
@@ -5,7 +5,7 @@ module Algolia
 
       # Initialize a config
       #
-      # @option options [String] :app_id
+      # @option options [String] :application_id
       # @option options [String] :api_key
       # @option options [String] :region
       #

--- a/lib/algolia/config/base_config.rb
+++ b/lib/algolia/config/base_config.rb
@@ -6,7 +6,7 @@ module Algolia
                   :symbolize_keys
 
     #
-    # @option options [String] :app_id
+    # @option options [String] :application_id
     # @option options [String] :api_key
     # @option options [Integer] :batch_size
     # @option options [Integer] :read_timeout
@@ -15,10 +15,10 @@ module Algolia
     # @option options [Boolean] :symbolize_keys
     #
     def initialize(opts = {})
-      raise AlgoliaError, 'No Application ID provided, please set :app_id' unless opts.has_key?(:app_id)
+      raise AlgoliaError, 'No Application ID provided, please set :application_id' unless opts.has_key?(:application_id)
       raise AlgoliaError, 'No API key provided, please set :api_key' unless opts.has_key?(:api_key)
 
-      @app_id  = opts[:app_id]
+      @app_id  = opts[:application_id]
       @api_key = opts[:api_key]
 
       @headers = {

--- a/lib/algolia/config/insights_config.rb
+++ b/lib/algolia/config/insights_config.rb
@@ -5,7 +5,7 @@ module Algolia
 
       # Initialize a config
       #
-      # @option options [String] :app_id
+      # @option options [String] :application_id
       # @option options [String] :api_key
       # @option options [String] :region
       #

--- a/lib/algolia/config/recommendation_config.rb
+++ b/lib/algolia/config/recommendation_config.rb
@@ -5,7 +5,7 @@ module Algolia
 
       # Initialize a config
       #
-      # @option options [String] :app_id
+      # @option options [String] :application_id
       # @option options [String] :api_key
       # @option options [String] :region
       #

--- a/lib/algolia/config/search_config.rb
+++ b/lib/algolia/config/search_config.rb
@@ -11,7 +11,7 @@ module Algolia
 
       # Initialize a config
       #
-      # @option options [String] :app_id
+      # @option options [String] :application_id
       # @option options [String] :api_key
       # @option options [Hash] :custom_hosts
       #

--- a/lib/algolia/insights_client.rb
+++ b/lib/algolia/insights_client.rb
@@ -26,7 +26,7 @@ module Algolia
       # @return self
       #
       def self.create(app_id, api_key)
-        config = Insights::Config.new(app_id: app_id, api_key: api_key)
+        config = Insights::Config.new(application_id: app_id, api_key: api_key)
         create_with_config(config)
       end
 

--- a/lib/algolia/recommendation_client.rb
+++ b/lib/algolia/recommendation_client.rb
@@ -24,7 +24,7 @@ module Algolia
       # @return self
       #
       def self.create(app_id, api_key)
-        config = Recommendation::Config.new(app_id: app_id, api_key: api_key)
+        config = Recommendation::Config.new(application_id: app_id, api_key: api_key)
         create_with_config(config)
       end
 

--- a/lib/algolia/search_client.rb
+++ b/lib/algolia/search_client.rb
@@ -32,7 +32,7 @@ module Algolia
       # @return self
       #
       def self.create(app_id, api_key)
-        config = Search::Config.new(app_id: app_id, api_key: api_key)
+        config = Search::Config.new(application_id: app_id, api_key: api_key)
         create_with_config(config)
       end
 

--- a/test/algolia/unit/retry_strategy_test.rb
+++ b/test/algolia/unit/retry_strategy_test.rb
@@ -13,7 +13,7 @@ class RetryStrategyTest
       stateful_hosts << "#{@app_id}-4.algolianet.com"
       stateful_hosts << "#{@app_id}-5.algolianet.com"
       stateful_hosts << "#{@app_id}-6.algolianet.com"
-      @config        = Algolia::Search::Config.new(app_id: @app_id, api_key: @api_key, custom_hosts: stateful_hosts)
+      @config        = Algolia::Search::Config.new(application_id: @app_id, api_key: @api_key, custom_hosts: stateful_hosts)
     end
 
     def test_resets_expired_hosts_according_to_read_type
@@ -74,7 +74,7 @@ class RetryStrategyTest
   describe 'All hosts are unreachable' do
     def test_failure_when_all_hosts_are_down
       stateful_hosts = ['0.0.0.0']
-      @config        = Algolia::Search::Config.new(app_id: 'foo', api_key: 'bar', custom_hosts: stateful_hosts)
+      @config        = Algolia::Search::Config.new(application_id: 'foo', api_key: 'bar', custom_hosts: stateful_hosts)
       client         = Algolia::Search::Client.create_with_config(@config)
       index          = client.init_index(get_test_index_name('failure'))
 
@@ -91,7 +91,7 @@ class RetryStrategyTest
       super
       @app_id         = 'app_id'
       @api_key        = 'api_key'
-      @config         = Algolia::Search::Config.new(app_id: @app_id, api_key: @api_key)
+      @config         = Algolia::Search::Config.new(application_id: @app_id, api_key: @api_key)
       @retry_strategy = Algolia::Transport::RetryStrategy.new(@config)
       @hosts          = @retry_strategy.get_tryable_hosts(READ|WRITE)
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,7 @@ class Minitest::Test
 
   include Minitest::Hooks
   include Helpers
-  @@search_config = Algolia::Search::Config.new(app_id: APPLICATION_ID_1, api_key: ADMIN_KEY_1, user_agent: USER_AGENT)
+  @@search_config = Algolia::Search::Config.new(application_id: APPLICATION_ID_1, api_key: ADMIN_KEY_1, user_agent: USER_AGENT)
   @@search_client = Algolia::Search::Client.new(@@search_config)
 end
 

--- a/upgrade_guide.md
+++ b/upgrade_guide.md
@@ -38,7 +38,7 @@ index = client.init_index('index_name')
 client = Algolia::Search::Client.create('APP_ID', 'API_KEY')
 index = client.init_index('index_name')
 # or
-search_config = Algolia::Search::Config.new(app_id: app_id, api_key: api_key)
+search_config = Algolia::Search::Config.new(application_id: app_id, api_key: api_key)
 client = Algolia::Search::Client.create_with_config(search_config)
 index = client.init_index('index_name')
 ```
@@ -578,6 +578,6 @@ client = Algolia::Client.new({
 })
 
 # After
-search_config = Algolia::Search::Config.new(app_id: 'app_id', api_key: 'api_key', read_timeout: 10, connect_timeout: 2)
+search_config = Algolia::Search::Config.new(application_id: 'app_id', api_key: 'api_key', read_timeout: 10, connect_timeout: 2)
 client = Algolia::Search::Client.create_with_config(search_config)
 ```


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no

## Describe your change

Renames `app_id` to `application_id` to smooth the upgrading and avoid BC breaks on Rails integration