### PR TITLE
fix(rules): export rules hitsPerPage

### DIFF
--- a/lib/algolia/index.rb
+++ b/lib/algolia/index.rb
@@ -1266,7 +1266,7 @@ module Algolia
       res = []
       page = 0
       loop do
-        curr = search_rules('', { :hits_per_page => hits_per_page, :page => page }, request_options)['hits']
+        curr = search_rules('', { :hitsPerPage => hits_per_page, :page => page }, request_options)['hits']
         curr.each do |rule|
           res << rule
           yield rule if block_given?


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     


## Describe your change

The `hitsPerPage` param had a typo, preventing the rule browser from retrieving all the rules. It's been fixed