### PR TITLE
chore: update faraday dependency range

### DIFF
--- a/algolia.gemspec
+++ b/algolia.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '<= 0.82.0'
 
-  spec.add_dependency 'faraday', '~> 0.15'
+  spec.add_dependency 'faraday', ['>= 0.15', '< 2.0']
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'net-http-persistent'
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no   
| Related Issue     | Fix #431 


## Describe your change

Updates the dependency range of `faraday` gem to allow versions > 1.0