### PR TITLE
Don't mutate index name when stripping

### DIFF
--- a/lib/algolia/search_client.rb
+++ b/lib/algolia/search_client.rb
@@ -90,11 +90,11 @@ module Algolia
       # @return [Index] new Index instance
       #
       def init_index(index_name)
-        index_name.strip!
-        if index_name.empty?
+        stripped_index_name = index_name.strip
+        if stripped_index_name.empty?
           raise AlgoliaError, 'Please provide a valid index name'
         end
-        Index.new(index_name, @transporter, @config)
+        Index.new(stripped_index_name, @transporter, @config)
       end
 
       # List all indexes of the client


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      |no
| BC breaks?        | no     
| Related Issue     | None
| Need Doc update   | no


## Describe your change

Using `strip` instead of `strip!` in `init_index`.

## What problem is this fixing?

Currently calling `init_index` with a frozen string causes a `FrozenError` as the method tries to mutate `index_name`. Using `strip` instead of `strip!` gives the same value without mutation.
