### PR TITLE
refactor(synonyms): rename replaceExistingSynonyms

### DIFF
--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -660,9 +660,10 @@ module Algolia
           request_options.delete(:forwardToReplicas)
         end
 
-        if request_options[:replaceExistingSynonyms]
+        if request_options[:replaceExistingSynonyms] || request_options[:clearExistingSynonyms]
           replace_existing_synonyms = true
           request_options.delete(:replaceExistingSynonyms)
+          request_options.delete(:clearExistingSynonyms)
         end
         response = @transporter.write(
           :POST,
@@ -893,7 +894,7 @@ module Algolia
       #
       def replace_all_synonyms(synonyms, opts = {})
         request_options                           = symbolize_hash(opts)
-        request_options[:replaceExistingSynonyms] = true
+        request_options[:clearExistingSynonyms] = true
 
         save_synonyms(synonyms, request_options)
       end

--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -893,7 +893,7 @@ module Algolia
       # @return [Array, IndexingResponse]
       #
       def replace_all_synonyms(synonyms, opts = {})
-        request_options                           = symbolize_hash(opts)
+        request_options                         = symbolize_hash(opts)
         request_options[:clearExistingSynonyms] = true
 
         save_synonyms(synonyms, request_options)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #438 
| Need Doc update   | yes

## Describe your change

In the method `saveSynonyms`, rename the parameter `replaceExistingSynonyms` to `clearExistingSynonyms`