### PR TITLE
fix(api-keys): send opts with waitable method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/algolia/algoliasearch-client-ruby/compare/2.0.3...master)
 
+### Fix
+- `app_api_key`: send opts with waitable method
+
 ## [2.0.3](https://github.com/algolia/algoliasearch-client-ruby/compare/2.0.2...2.0.3) (2020-11-24)
 
 ### Chore

--- a/lib/algolia/search_client.rb
+++ b/lib/algolia/search_client.rb
@@ -300,7 +300,7 @@ module Algolia
       # @return [AddApiKeyResponse]
       #
       def add_api_key!(acl, opts = {})
-        response = add_api_key(acl)
+        response = add_api_key(acl, opts)
 
         response.wait(opts)
       end

--- a/test/algolia/integration/search_client_test.rb
+++ b/test/algolia/integration/search_client_test.rb
@@ -215,6 +215,7 @@ class SearchClientTest < BaseTest
 
     def test_api_keys
       assert_equal ['search'], @api_key[:acl]
+      assert_equal 'A description', @api_key[:description]
 
       api_keys = @@search_client.list_api_keys[:keys].map do |key|
         key[:value]


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

The request options were not send in the waitable version of `app_api_key`