### PR TITLE
feat: add support for Ruby v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ workflows:
       - test_ruby:
           matrix:
             parameters:
-              version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7']
+              version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
           filters:
             tags:
               only: /.*/

--- a/test/algolia/integration/search_client_test.rb
+++ b/test/algolia/integration/search_client_test.rb
@@ -409,14 +409,21 @@ class SearchClientTest < BaseTest
         stopwords_settings = {
           disableStandardEntries: {
             stopwords: {
-              en: true
+              en: true,
+              fr: false
             }
           }
         }
 
         @client.set_dictionary_settings!(stopwords_settings)
 
-        assert_equal @client.get_dictionary_settings, stopwords_settings
+        assert_equal @client.get_dictionary_settings, {
+          disableStandardEntries: {
+            stopwords: {
+              en: true
+            }
+          }
+        }
       end
 
       def test_plurals_dictionaries

--- a/test/algolia/integration/search_client_test.rb
+++ b/test/algolia/integration/search_client_test.rb
@@ -409,21 +409,14 @@ class SearchClientTest < BaseTest
         stopwords_settings = {
           disableStandardEntries: {
             stopwords: {
-              en: true,
-              fr: false
+              en: true
             }
           }
         }
 
         @client.set_dictionary_settings!(stopwords_settings)
 
-        assert_equal @client.get_dictionary_settings, {
-          disableStandardEntries: {
-            stopwords: {
-              en: true
-            }
-          }
-        }
+        assert_equal @client.get_dictionary_settings, stopwords_settings
       end
 
       def test_plurals_dictionaries


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no (?)
| Need Doc update   | yes/no


## Describe your change
This PR is meant to add support for version 3 of Ruby, which was released on 25 December 2020.

The following dependencies don't support Ruby v3 yet, meaning we can't upgrade for now:
- [`net-http-persistent`](https://github.com/drbrain/net-http-persistent/) (https://github.com/drbrain/net-http-persistent/issues/123)
