### PR TITLE
fix(set-settings): forwardToReplicas param

### DIFF
--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -987,13 +987,8 @@ module Algolia
       # @return [IndexingResponse]
       #
       def set_settings(settings, opts = {})
-        forward_to_replicas  = false
         request_options      = symbolize_hash(opts)
-
-        if request_options[:forwardToReplicas]
-          forward_to_replicas = true
-          request_options.delete(:forwardToReplicas)
-        end
+        forward_to_replicas  = request_options.delete(:forwardToReplicas) || false
 
         response = @transporter.write(
           :PUT,

--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -987,7 +987,20 @@ module Algolia
       # @return [IndexingResponse]
       #
       def set_settings(settings, opts = {})
-        response = @transporter.write(:PUT, path_encode('/1/indexes/%s/settings', @name), settings, opts)
+        forward_to_replicas  = false
+        request_options      = symbolize_hash(opts)
+
+        if request_options[:forwardToReplicas]
+          forward_to_replicas = true
+          request_options.delete(:forwardToReplicas)
+        end
+
+        response = @transporter.write(
+          :PUT,
+          path_encode('/1/indexes/%s/settings', @name) + handle_params({ forwardToReplicas: forward_to_replicas }),
+          settings,
+          request_options
+        )
 
         IndexingResponse.new(self, response)
       end

--- a/test/algolia/integration/search_index_test.rb
+++ b/test/algolia/integration/search_index_test.rb
@@ -274,6 +274,9 @@ class SearchIndexTest < BaseTest
       @index.set_settings!(settings)
 
       assert_equal @index.get_settings, settings
+
+      # check that the forwardToReplicas parameter is passed correctly
+      assert @index.set_settings!(settings, { forwardToReplicas: true })
     end
   end
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #450
| Need Doc update   | yes/no

The parameter `forwardToReplicas` should be handled independently in the `set_settings` method