### PR TITLE
fix: Memoize host based on accept attribute

### DIFF
--- a/lib/algolia/http/http_requester.rb
+++ b/lib/algolia/http/http_requester.rb
@@ -9,8 +9,8 @@ module Algolia
       # @param logger [Object] logger used to log requests. Defaults to Algolia::LoggerHelper
       #
       def initialize(adapter, logger)
-        @adapter    = adapter
-        @logger     = logger
+        @adapter     = adapter
+        @logger      = logger
         @connections = []
       end
 

--- a/lib/algolia/http/http_requester.rb
+++ b/lib/algolia/http/http_requester.rb
@@ -11,7 +11,7 @@ module Algolia
       def initialize(adapter, logger)
         @adapter     = adapter
         @logger      = logger
-        @connections = []
+        @connections = {}
       end
 
       # Sends request to the engine

--- a/lib/algolia/http/http_requester.rb
+++ b/lib/algolia/http/http_requester.rb
@@ -11,7 +11,7 @@ module Algolia
       def initialize(adapter, logger)
         @adapter    = adapter
         @logger     = logger
-        @connection = nil
+        @connections = []
       end
 
       # Sends request to the engine
@@ -65,7 +65,7 @@ module Algolia
       # @return [Faraday::Connection]
       #
       def connection(host)
-        @connection ||= Faraday.new(build_url(host)) do |f|
+        @connections[host.accept] ||= Faraday.new(build_url(host)) do |f|
           f.adapter @adapter.to_sym
         end
       end


### PR DESCRIPTION
Before this change a read-only host could get memoized preventing writes in subsequent requests.

Closes #454

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #454 
| Need Doc update   | no


## Describe your change

Before this change the first used host would get memoized. If this was a read-only host, then future requests would also use this read-only host. Even if this requests would require a write host.

This PR fixes that bug. The existing code comments already referred to a `@connections` variable. So I think this solution might have been implemented before, but got removed for some reason.

I couldn't get the test suite to run, so I suggest doing that before merging this PR. I also suggest adding a spec that fails without this PR. So that this bug doesn't re-occur in the future.

## What problem is this fixing?

See above.