### PR TITLE
 chore: add `search` alias for multiple queries

### DIFF
--- a/lib/algolia/search_client.rb
+++ b/lib/algolia/search_client.rb
@@ -480,6 +480,7 @@ module Algolia
       def multiple_queries(queries, opts = {})
         @transporter.read(:POST, '/1/indexes/*/queries', { requests: queries }, opts)
       end
+      alias_method :search, :multiple_queries
 
       # # # # # # # # # # # # # # # # # # # # #
       # MCM METHODS


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | yes


## Describe your change
This adds `search` as an alias for the `multiple_queries` method to align method names across all API clients.
