### PR TITLE
fix: always remove createIfNotExists from request options

### DIFF
--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -301,8 +301,8 @@ module Algolia
         request_options    = symbolize_hash(opts)
         if get_option(request_options, 'createIfNotExists')
           generate_object_id = true
-          request_options.delete(:createIfNotExists)
         end
+        request_options.delete(:createIfNotExists)
 
         if generate_object_id
           IndexingResponse.new(self, raw_batch(chunk('partialUpdateObject', objects), request_options))


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     

## Describe your change
This ensures we _always_ remove `createIfNotExists` from our request options. Currently, if you pass it as `false`, [this check](https://github.com/algolia/algoliasearch-client-ruby/pull/458/files#diff-d9ee2258a9e0d0149752df99fc31eb433f3c62cb36d2966b72198cdc924ced43R302) fails. Because of that, we're trying to send a `partialUpdateObjectNoCreate` operation, which doesn't accept the `createIfNotExists` parameter, even if it's `false`. By removing the parameter from our request options we prevent this from happening.
