### PR TITLE
fix: add status field to `MockRequester` response

### DIFF
--- a/test/algolia/integration/mocks/mock_requester.rb
+++ b/test/algolia/integration/mocks/mock_requester.rb
@@ -20,7 +20,7 @@ class MockRequester
 
     Algolia::Http::Response.new(
       status: 200,
-      body: '{"hits": []}',
+      body: '{"hits": [], "status": "published"}',
       headers: {}
     )
   end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     

## Describe your change
This adds the `status` field to the response provided by the `MockRequester`. This prevents an infinite loop while using the `MockRequester` to perform a `wait_task`.