### PR TITLE
fix: allow hash in multiple queries

### DIFF
--- a/lib/algolia/search_client.rb
+++ b/lib/algolia/search_client.rb
@@ -478,6 +478,9 @@ module Algolia
       # @return [Hash]
       #
       def multiple_queries(queries, opts = {})
+        queries.map! do |q|
+          q[:params] = to_query_string(q[:params]) unless q[:params].is_a? String
+        end
         @transporter.read(:POST, '/1/indexes/*/queries', { requests: queries }, opts)
       end
       alias_method :search, :multiple_queries

--- a/lib/algolia/search_client.rb
+++ b/lib/algolia/search_client.rb
@@ -478,8 +478,8 @@ module Algolia
       # @return [Hash]
       #
       def multiple_queries(queries, opts = {})
-        queries.map! do |q|
-          q[:params] = to_query_string(q[:params]) unless q[:params].is_a? String
+        queries.each do |q|
+          q[:params] = to_query_string(q[:params]) unless q[:params].is_a?(String)
         end
         @transporter.read(:POST, '/1/indexes/*/queries', { requests: queries }, opts)
       end

--- a/test/algolia/integration/search_client_test.rb
+++ b/test/algolia/integration/search_client_test.rb
@@ -294,7 +294,7 @@ class SearchClientTest < BaseTest
 
       results = @@search_client.multiple_queries([
         { indexName: index_name1, params: to_query_string({ query: '', hitsPerPage: 2 }) },
-        { indexName: index_name2, params: to_query_string({ query: '', hitsPerPage: 2 }) }
+        { indexName: index_name2, params: { query: '', hitsPerPage: 2 } }
       ], { strategy: 'none' })[:results]
 
       assert_equal 2, results.length

--- a/test/algolia/integration/search_client_test.rb
+++ b/test/algolia/integration/search_client_test.rb
@@ -409,7 +409,8 @@ class SearchClientTest < BaseTest
         stopwords_settings = {
           disableStandardEntries: {
             stopwords: {
-              en: true
+              en: true,
+              fr: true
             }
           }
         }

--- a/test/algolia/integration/search_client_test.rb
+++ b/test/algolia/integration/search_client_test.rb
@@ -409,8 +409,7 @@ class SearchClientTest < BaseTest
         stopwords_settings = {
           disableStandardEntries: {
             stopwords: {
-              en: true,
-              fr: false
+              en: true
             }
           }
         }

--- a/test/algolia/integration/search_client_test.rb
+++ b/test/algolia/integration/search_client_test.rb
@@ -410,7 +410,7 @@ class SearchClientTest < BaseTest
           disableStandardEntries: {
             stopwords: {
               en: true,
-              fr: true
+              fr: false
             }
           }
         }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #462 
| Need Doc update   | no

## Describe your change
This updates the client to accept a hash for `params` when performing a `multiple_queries`, rather than only accepting a string.
