### PR TITLE
fix: API polling flood issue due to msec sleep time mishandling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ If you were using the v1 and wish to update to v2, please follow our [Upgrade Gu
 ## 📄 License
 
 Algolia Ruby API Client is an open-sourced software licensed under the [MIT license](LICENSE.md).
+

--- a/README.md
+++ b/README.md
@@ -62,4 +62,3 @@ If you were using the v1 and wish to update to v2, please follow our [Upgrade Gu
 ## 📄 License
 
 Algolia Ruby API Client is an open-sourced software licensed under the [MIT license](LICENSE.md).
-

--- a/lib/algolia/responses/add_api_key_response.rb
+++ b/lib/algolia/responses/add_api_key_response.rb
@@ -28,7 +28,7 @@ module Algolia
           end
           retries_count    += 1
           time_before_retry = retries_count * Defaults::WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY
-          sleep(time_before_retry / 1000)
+          sleep(time_before_retry.to_f / 1000)
         end
       end
 

--- a/lib/algolia/responses/delete_api_key_response.rb
+++ b/lib/algolia/responses/delete_api_key_response.rb
@@ -29,7 +29,7 @@ module Algolia
           unless @done
             retries_count    += 1
             time_before_retry = retries_count * Defaults::WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY
-            sleep(time_before_retry / 1000)
+            sleep(time_before_retry.to_f / 1000)
           end
         end
       end

--- a/lib/algolia/responses/restore_api_key_response.rb
+++ b/lib/algolia/responses/restore_api_key_response.rb
@@ -26,7 +26,7 @@ module Algolia
           end
           retries_count    += 1
           time_before_retry = retries_count * Defaults::WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY
-          sleep(time_before_retry / 1000)
+          sleep(time_before_retry.to_f / 1000)
         end
       end
 

--- a/lib/algolia/responses/update_api_key_response.rb
+++ b/lib/algolia/responses/update_api_key_response.rb
@@ -29,7 +29,7 @@ module Algolia
           raise e unless e.code == 404
           retries_count    += 1
           time_before_retry = retries_count * Defaults::WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY
-          sleep(time_before_retry / 1000)
+          sleep(time_before_retry.to_f / 1000)
         end
       end
 

--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -36,7 +36,7 @@ module Algolia
           if status == 'published'
             return
           end
-          sleep(time_before_retry / 1000)
+          sleep(time_before_retry.to_f / 1000)
         end
       end
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | -
| Need Doc update   | no


## Describe your change

There are some `sleep` with `Defaults::WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY / 1000` and the constant variable is `100` as 100 milliseconds.
However, `100 / 1000` is `0` calculated as Integer.
So, I fix it to `100.to_f / 1000` for 100 msec sleeping.

The changes in `lib/algolia/responses/*.rb` are not so important because these are irregular error handling logic and sleep time is increased by retry count.
On the other hand, `lib/algolia/search_index.rb` is important.
It's normal logic that occurs frequently.

Ref. I found out similar logic [here](https://github.com/algolia/algoliasearch-client-ruby/blob/052e96149abb31c67a5ddf3ec2fda9504c3ce8bf/lib/algolia/search_client.rb#L64) that handles the msec as float correctly.


## What problem is this fixing?

When you use the search method, especially with index settings changes, the client generates API call flood for the status check polling.
This PR reduces the flood, increases the interval of API calls.
