### PR TITLE
fix: API endpoint URL mishandling in get_settings method

### DIFF
--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -977,8 +977,8 @@ module Algolia
         opts_default = {
           getVersion: 2
         }
-        opts     = opts_default.merge(opts)
-        response = @transporter.read(:GET, path_encode('/1/indexes/%s/settings', @name), {}, opts)
+        opts         = opts_default.merge(opts)
+        response     = @transporter.read(:GET, path_encode('/1/indexes/%s/settings', @name), {}, opts)
 
         deserialize_settings(response, @config.symbolize_keys)
       end

--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -974,7 +974,11 @@ module Algolia
       # @return [Hash]
       #
       def get_settings(opts = {})
-        response = @transporter.read(:GET, path_encode('/1/indexes/%s/settings', @name) + handle_params({ getVersion: 2 }), {}, opts)
+        opts_default = {
+          getVersion: 2
+        }
+        opts     = opts_default.merge(opts)
+        response = @transporter.read(:GET, path_encode('/1/indexes/%s/settings', @name), {}, opts)
 
         deserialize_settings(response, @config.symbolize_keys)
       end

--- a/test/algolia/integration/search_index_test.rb
+++ b/test/algolia/integration/search_index_test.rb
@@ -277,13 +277,34 @@ class SearchIndexTest < BaseTest
 
       # check that the forwardToReplicas parameter is passed correctly
       assert @index.set_settings!(settings, { forwardToReplicas: true })
+    end
 
-      # Check version 1 API calling (ref. PR #473)
-      # Currently, only the 'version' key's value in API response is checked.
+    # Check version 1 API calling (ref. PR #473)
+    def test_version_param
+      @index.save_object!(generate_object('obj1')) # create index
+
+      # Check response's version value by actual access
+      assert_equal 2, @index.get_settings[:version]
       assert_equal 1, @index.get_settings(getVersion: 1)[:version]
+      assert_equal 2, @index.get_settings(getVersion: 2)[:version]
 
-      # To detect changes in backend behavior (ref. PR #473)
-      assert_equal 18446744073709551615, @index.get_settings(getVersion: 'invalid string')[:version]
+      # Check API endpoint handling by mock access
+      requester = MockRequester.new
+      client    = Algolia::Search::Client.new(@@search_config, http_requester: requester)
+      index     = client.init_index(@index_name)
+
+      index.get_settings # default
+      index.get_settings(getVersion: 1)
+      index.get_settings(getVersion: 2)
+
+      assert_requests(
+        requester,
+        [
+          { method: :get, path: "/1/indexes/#{@index_name}/settings?getVersion=2" },
+          { method: :get, path: "/1/indexes/#{@index_name}/settings?getVersion=1" },
+          { method: :get, path: "/1/indexes/#{@index_name}/settings?getVersion=2" }
+        ]
+      )
     end
   end
 

--- a/test/algolia/integration/search_index_test.rb
+++ b/test/algolia/integration/search_index_test.rb
@@ -277,6 +277,13 @@ class SearchIndexTest < BaseTest
 
       # check that the forwardToReplicas parameter is passed correctly
       assert @index.set_settings!(settings, { forwardToReplicas: true })
+
+      # Check version 1 API calling (ref. PR #473)
+      # Currently, only the 'version' key's value in API response is checked.
+      assert_equal 1, @index.get_settings(getVersion: 1)[:version]
+
+      # To detect changes in backend behavior (ref. PR #473)
+      assert_equal 18446744073709551615, @index.get_settings(getVersion: 'invalid string')[:version]
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,11 @@ def assert_requests(requester, requests)
   requests.each_with_index do |expected_request, i|
     request = actual_requests[i]
 
-    assert_equal(expected_request[:body], request[:body])
+    if expected_request[:body].nil? # for GET requests w/ NO body.
+      assert_nil(request[:body])
+    else
+      assert_equal(expected_request[:body], request[:body])
+    end
     assert_equal(expected_request[:method], request[:method])
     assert_equal(expected_request[:path], request[:path])
   end


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | -
| Need Doc update   | no


## Describe your change

When the `get_settings` method is called in [algoliasearch-rails gem](https://github.com/algolia/algoliasearch-rails/blob/2358e3ca6e3b2242a345b3e2d360e2099fbbc9d6/lib/algoliasearch-rails.rb#L796) with argument `(:getVersion => 1)`, the client send HTTP GET to `/1/indexes/%s/settings?getVersion=2?getVersion=1`
`?getVersion=2?getVersion=1` is invalid params and the API returns the JSON response contain `"version"=>18446744073709551615`.

This PR fix the HTTP GET target URL with some opts.

## What problem is this fixing?

- When you use `get_settings` method with some opts you may don't get a correct response.
- algoliasearch-rails gem may mis-detect the changes in index settings.