### PR TITLE
fix: #434: confusing empty debug.log generation in gem users root

### DIFF
--- a/lib/algolia/analytics_client.rb
+++ b/lib/algolia/analytics_client.rb
@@ -13,7 +13,7 @@ module Algolia
       def initialize(analytics_config, opts = {})
         @config      = analytics_config
         adapter      = opts[:adapter] || Defaults::ADAPTER
-        logger       = opts[:logger] || LoggerHelper.create('debug.log')
+        logger       = opts[:logger] || LoggerHelper.create
         requester    = opts[:http_requester] || Defaults::REQUESTER_CLASS.new(adapter, logger)
         @transporter = Transport::Transport.new(@config, requester)
       end

--- a/lib/algolia/insights_client.rb
+++ b/lib/algolia/insights_client.rb
@@ -13,7 +13,7 @@ module Algolia
       def initialize(insights_config, opts = {})
         @config      = insights_config
         adapter      = opts[:adapter] || Defaults::ADAPTER
-        logger       = opts[:logger] || LoggerHelper.create('debug.log')
+        logger       = opts[:logger] || LoggerHelper.create
         requester    = opts[:http_requester] || Defaults::REQUESTER_CLASS.new(adapter, logger)
         @transporter = Transport::Transport.new(@config, requester)
       end

--- a/lib/algolia/logger_helper.rb
+++ b/lib/algolia/logger_helper.rb
@@ -5,7 +5,7 @@ module Algolia
     # @param debug_file [nil|String] file used to output the logs
     #
     def self.create(debug_file = nil)
-      file              = debug_file || (ENV['ALGOLIA_DEBUG'] ? 'debug.log' : $stderr)
+      file              = debug_file || (ENV['ALGOLIA_DEBUG'] ? File.new('debug.log') : $stderr)
       instance          = ::Logger.new file
       instance.progname = 'algolia'
       instance

--- a/lib/algolia/logger_helper.rb
+++ b/lib/algolia/logger_helper.rb
@@ -5,7 +5,7 @@ module Algolia
     # @param debug_file [nil|String] file used to output the logs
     #
     def self.create(debug_file = nil)
-      file              = debug_file || File.new('debug.log')
+      file              = debug_file || (ENV['ALGOLIA_DEBUG'] ? 'debug.log' : STDERR)
       instance          = ::Logger.new file
       instance.progname = 'algolia'
       instance

--- a/lib/algolia/logger_helper.rb
+++ b/lib/algolia/logger_helper.rb
@@ -5,7 +5,7 @@ module Algolia
     # @param debug_file [nil|String] file used to output the logs
     #
     def self.create(debug_file = nil)
-      file              = debug_file || (ENV['ALGOLIA_DEBUG'] ? 'debug.log' : STDERR)
+      file              = debug_file || (ENV['ALGOLIA_DEBUG'] ? 'debug.log' : $stderr)
       instance          = ::Logger.new file
       instance.progname = 'algolia'
       instance

--- a/lib/algolia/personalization_client.rb
+++ b/lib/algolia/personalization_client.rb
@@ -11,7 +11,7 @@ module Algolia
       def initialize(personalization_config, opts = {})
         @config      = personalization_config
         adapter      = opts[:adapter] || Defaults::ADAPTER
-        logger       = opts[:logger] || LoggerHelper.create('debug.log')
+        logger       = opts[:logger] || LoggerHelper.create
         requester    = opts[:http_requester] || Defaults::REQUESTER_CLASS.new(adapter, logger)
         @transporter = Transport::Transport.new(@config, requester)
       end

--- a/lib/algolia/recommend_client.rb
+++ b/lib/algolia/recommend_client.rb
@@ -18,7 +18,7 @@ module Algolia
       def initialize(recommend_config, opts = {})
         @config      = recommend_config
         adapter      = opts[:adapter] || Defaults::ADAPTER
-        logger       = opts[:logger] || LoggerHelper.create('debug.log')
+        logger       = opts[:logger] || LoggerHelper.create
         requester    = opts[:http_requester] || Defaults::REQUESTER_CLASS.new(adapter, logger)
         @transporter = Transport::Transport.new(@config, requester)
       end

--- a/lib/algolia/search_client.rb
+++ b/lib/algolia/search_client.rb
@@ -19,7 +19,7 @@ module Algolia
       def initialize(search_config, opts = {})
         @config      = search_config
         adapter      = opts[:adapter] || Defaults::ADAPTER
-        logger       = opts[:logger] || LoggerHelper.create('debug.log')
+        logger       = opts[:logger] || LoggerHelper.create
         requester    = opts[:http_requester] || Defaults::REQUESTER_CLASS.new(adapter, logger)
         @transporter = Transport::Transport.new(@config, requester)
       end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #434
| Need Doc update   | no


## Describe your change

When you use this gem, your program generate `debug.log` in the working directory. ( ref. #434 )
If you set `ALGOLIA_DEBUG` environment and want to get some algolia gem logging to debug your program, this file is very useful.
However, in almost all situations `debug.log` is a seed of confusion, especially if you are just a program's user that uses this gem.

For general program users, they can't decide why the file is generated because the file is always empty.
Or for program developers who have .gitignore that doesn't contain the line `debug.log`, they might think it's annoying a little.

I understand that the developers can change the behavior by the `:logger` option in your code.
But I'm thinking it's not a bad idea to change the default behavior for the majority of users of this gem.

This PR **don't change** them.
1. If you set `ALGOLIA_DEBUG` env, this gem's behavior is the same as before.
2. If you use methods in this gem with the logger option, this gem's behavior is the same as before.

This PR **will change** below.
1. If you use methods in this gem without the `:logger` option or `ALGOLIA_DEBUG` env, this gem doesn't create `debug.log` in the working directory.
2. If you use `algoliasearch-rails` gem without `ALGOLIA_DEBUG` env as a general use case, this gem doesn't create emptry `debug.log` to your `RAILS_ROOT`.


## What problem is this fixing?

#434 

---

I'm considering that there is a lot of room for improvement around log handling, for eg method or argument name.
But this PR is focusing on default behavior improvement.
So, even if you feel a name mismatch in this PR code, please miss it.