### PR TITLE
fix(multiple_queries): allow params to be nil

### DIFF
--- a/lib/algolia/search_client.rb
+++ b/lib/algolia/search_client.rb
@@ -479,7 +479,7 @@ module Algolia
       #
       def multiple_queries(queries, opts = {})
         queries.each do |q|
-          q[:params] = to_query_string(q[:params]) unless q[:params].is_a?(String)
+          q[:params] = to_query_string(q[:params]) unless q[:params].nil? || q[:params].is_a?(String)
         end
         @transporter.read(:POST, '/1/indexes/*/queries', { requests: queries }, opts)
       end


### PR DESCRIPTION
| **Q** | **A** |
|----------------|-------|
| Bug fix?        | yes   |
| New feature?    | no    |
| BC breaks?      | no    |
| Need Doc update | no    |

## Describe your change
Skip call to `to_query_string` in `multiple_queries` if `:params` is nil

## What problem is this fixing?
`params` is documented as an optional argument of `multiple_queries`, but a recent change introducing a call to `to_query_string` triggers an error if `params` is not present (undefined method `map' for nil:NilClass)