### PR TITLE
Pass user configured logger to temp client in `replace_all_objects`

### DIFF
--- a/lib/algolia/search_client.rb
+++ b/lib/algolia/search_client.rb
@@ -19,8 +19,8 @@ module Algolia
       def initialize(search_config, opts = {})
         @config      = search_config
         adapter      = opts[:adapter] || Defaults::ADAPTER
-        logger       = opts[:logger] || LoggerHelper.create
-        requester    = opts[:http_requester] || Defaults::REQUESTER_CLASS.new(adapter, logger)
+        @logger      = opts[:logger] || LoggerHelper.create
+        requester    = opts[:http_requester] || Defaults::REQUESTER_CLASS.new(adapter, @logger)
         @transporter = Transport::Transport.new(@config, requester)
       end
 
@@ -94,7 +94,7 @@ module Algolia
         if stripped_index_name.empty?
           raise AlgoliaError, 'Please provide a valid index name'
         end
-        Index.new(stripped_index_name, @transporter, @config)
+        Index.new(stripped_index_name, @transporter, @config, @logger)
       end
 
       # List all indexes of the client

--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -5,18 +5,20 @@ module Algolia
       include CallType
       include Helpers
 
-      attr_reader :name, :transporter, :config
+      attr_reader :name, :transporter, :config, :logger
 
       # Initialize an index
       #
       # @param name [String] name of the index
       # @param transporter [Object] transport object used for the connection
       # @param config [Config] a Config object which contains your APP_ID and API_KEY
+      # @param logger [LoggerHelper] an optional LoggerHelper object to use
       #
-      def initialize(name, transporter, config)
+      def initialize(name, transporter, config, logger = nil)
         @name        = name
         @transporter = transporter
         @config      = config
+        @logger      = logger || LoggerHelper.create
       end
 
       # # # # # # # # # # # # # # # # # # # # #
@@ -830,7 +832,7 @@ module Algolia
         end
 
         # TODO: consider create a new client with state of retry is shared
-        tmp_client = Algolia::Search::Client.new(@config)
+        tmp_client = Algolia::Search::Client.new(@config, { logger: logger })
         tmp_index  = tmp_client.init_index(tmp_index_name)
 
         save_objects_response = tmp_index.save_objects(objects, request_options)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | ?


## Describe your change
This change adds an optional parameter when constructing an index for the `logger` and allows that to be passed in to the temporary client. This change also ensures that any `Index` built through the `SearchClient#init_index` call gets the logger configured on the client. This will ensure logging is done in a consistent manner across clients instantiated by the library.

## What problem is this fixing?

The `replace_all_objects` method creates a temporary client which does not have the some configuration as one constructed by users of the library. This leads to inconsistent behaviour when a custom `LoggerHelper` is configured and passed to a new client and that client is used to initialize an index and the `replace_all_objects` operation is performed.

This issue is especially problematic in environments like Heroku where you want to log to `$stdout` or `$stderr`, instead of the default `debug.log` file.

### Steps to reproduce

1. With `ALGOLIA_DEBUG=true` set in ENV
2. Instantiate a client with a custom logging configuration
3. Initialize an index and call `replace_all_objects`
4. Logs from the `tmp_client` will still be written to `debug.log`

### Example
```ruby
config = Algolia::Search::Config.new(application_id: "APP_ID", api_key: "WRITE_API_KEY")
client = Algolia::Search::Client.new(config, {logger: Algolia::LoggerHelper.create($stdout)})
index = client.init_index("temp_index")
index.replace_all_objects([{objectID: :bar}, {objectID: :baz}])
```

#### Before this change
```
I, [2022-06-20T13:55:14.462743 #74331]  INFO -- algolia: Sending POST request to /1/indexes/temp_index/operation with body {"operation":"copy","destination":"temp_index_tmp_8549959","scope":["settings","synonyms","rules"]}
I, [2022-06-20T13:55:14.735881 #74331]  INFO -- algolia: Request succeeded. Response status: 200, body: {"updatedAt":"2022-06-20T20:55:14.811Z","taskID":669479654001}
Errno::ENOENT: No such file or directory @ rb_sysopen - debug.log from /Users/chris/.gem/ruby/2.7.5/gems/algolia-2.2.5/lib/algolia/logger_helper.rb:8:in `initialize'
```
#### After this change
```
I, [2022-06-20T13:45:06.500821 #73794]  INFO -- algolia: Sending POST request to /1/indexes/temp_index/operation with body {"operation":"copy","destination":"temp_index_tmp_4895079","scope":["settings","synonyms","rules"]}
I, [2022-06-20T13:45:06.747867 #73794]  INFO -- algolia: Request succeeded. Response status: 200, body: {"updatedAt":"2022-06-20T20:45:06.823Z","taskID":669476582001}
I, [2022-06-20T13:45:06.748419 #73794]  INFO -- algolia: Sending POST request to /1/indexes/temp_index_tmp_4895079/batch with body {"requests":[{"action":"updateObject","body":{"objectID":"bar"},"objectID":"bar"},{"action":"updateObject","body":{"objectID":"baz"},"objectID":"baz"}]}
I, [2022-06-20T13:45:06.995215 #73794]  INFO -- algolia: Request succeeded. Response status: 200, body: {"objectIDs":["bar","baz"],"taskID":669476583001}
I, [2022-06-20T13:45:06.995427 #73794]  INFO -- algolia: Sending POST request to /1/indexes/temp_index_tmp_4895079/operation with body {"operation":"move","destination":"temp_index"}
I, [2022-06-20T13:45:07.053036 #73794]  INFO -- algolia: Request succeeded. Response status: 200, body: {"updatedAt":"2022-06-20T20:45:07.128Z","taskID":669476584001}
```