### PR TITLE
chore: drop support for older Ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ workflows:
       - test_jruby:
           matrix:
             parameters:
-              version: ['9.1', '9.2']
+              version: ['9.2', '9.3']
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ workflows:
       - test_jruby:
           matrix:
             parameters:
-              version: ['9.2', '9.3']
+              version: ['9.2']
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ workflows:
       - test_ruby:
           matrix:
             parameters:
-              version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
+              version: ['2.4', '2.5', '2.6', '2.7', '3.0']
           filters:
             tags:
               only: /.*/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## ✨ Features
 
 - Thin & minimal low-level HTTP client to interact with Algolia's API
-- Supports Ruby `^2.2`.
+- Supports Ruby `^2.4`.
 
 ## 💡 Getting Started
 

--- a/algolia.gemspec
+++ b/algolia.gemspec
@@ -35,7 +35,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '<= 0.82.0'
 
-  spec.add_dependency 'faraday', ['>= 0.15', '< 2.0']
+  spec.add_dependency 'faraday', ['>= 0.15', '< 3']
+  spec.add_dependency 'faraday-net_http_persistent', ['>= 0.15', '< 3']
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'net-http-persistent'
 

--- a/algolia.gemspec
+++ b/algolia.gemspec
@@ -35,10 +35,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '<= 0.82.0'
 
-  faraday_range = ['>= 0.15', RUBY_VERSION <= '2.3' ? '< 2' : '< 3']
-
-  spec.add_dependency 'faraday', faraday_range
-  spec.add_dependency 'faraday-net_http_persistent', faraday_range
+  spec.add_dependency 'faraday', ['>= 0.15', '< 3']
+  spec.add_dependency 'faraday-net_http_persistent', ['>= 0.15', '< 3']
 
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'net-http-persistent'

--- a/algolia.gemspec
+++ b/algolia.gemspec
@@ -35,8 +35,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '<= 0.82.0'
 
-  spec.add_dependency 'faraday', ['>= 0.15', '< 3']
-  spec.add_dependency 'faraday-net_http_persistent', ['>= 0.15', '< 3']
+  faraday_range = ['>= 0.15', RUBY_VERSION <= '2.3' ? '< 2' : '< 3']
+
+  spec.add_dependency 'faraday', faraday_range
+  spec.add_dependency 'faraday-net_http_persistent', faraday_range
+
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'net-http-persistent'
 

--- a/lib/algolia/transport/transport.rb
+++ b/lib/algolia/transport/transport.rb
@@ -1,4 +1,6 @@
 require 'faraday'
+# this is the default adapter and it needs to be required to be registered.
+require 'faraday/net_http_persistent'
 
 module Algolia
   module Transport


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | yes


## Describe your change
This PR drops support for older Ruby versions, which are EOL for a while and are currently blocking a dependency upgrade.