### PR TITLE
fix: add check for Faraday version

### DIFF
--- a/lib/algolia/transport/transport.rb
+++ b/lib/algolia/transport/transport.rb
@@ -1,6 +1,6 @@
 require 'faraday'
 # this is the default adapter and it needs to be required to be registered.
-require 'faraday/net_http_persistent'
+require 'faraday/net_http_persistent' unless Faraday::VERSION < '1'
 
 module Algolia
   module Transport


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #484
| Need Doc update   | no


## Describe your change
This PR fixes the issue described in #484, for projects that have Faraday `<1` as a dependency
