### PR TITLE
feat: stop waiting for task after x seconds

### DIFF
--- a/lib/algolia/config/base_config.rb
+++ b/lib/algolia/config/base_config.rb
@@ -3,7 +3,7 @@ require 'faraday'
 module Algolia
   class BaseConfig
     attr_accessor :app_id, :api_key, :headers, :batch_size, :read_timeout, :write_timeout, :connect_timeout, :compression_type,
-                  :symbolize_keys, :use_latest_settings
+                  :symbolize_keys, :wait_task_timeout, :use_latest_settings
 
     #
     # @option options [String] :application_id
@@ -12,6 +12,7 @@ module Algolia
     # @option options [Integer] :read_timeout
     # @option options [Integer] :write_timeout
     # @option options [Integer] :connect_timeout
+    # @option options [Integer] :wait_task_timeout
     # @option options [Boolean] :symbolize_keys
     #
     def initialize(opts = {})
@@ -32,6 +33,7 @@ module Algolia
       @read_timeout        = opts[:read_timeout] || Defaults::READ_TIMEOUT
       @write_timeout       = opts[:write_timeout] || Defaults::WRITE_TIMEOUT
       @connect_timeout     = opts[:connect_timeout] || Defaults::CONNECT_TIMEOUT
+      @wait_task_timeout   = opts[:wait_task_timeout]
       @compression_type    = opts[:compression_type] || Defaults::NONE_ENCODING
       @symbolize_keys      = opts.has_key?(:symbolize_keys) ? opts[:symbolize_keys] : true
     end

--- a/lib/algolia/error.rb
+++ b/lib/algolia/error.rb
@@ -12,6 +12,11 @@ module Algolia
   class AlgoliaUnreachableHostError < AlgoliaError
   end
 
+  # Used when waiting a tasks times out
+  #
+  class AlgoliaWaitTaskTimedOutError < AlgoliaError
+  end
+
   # An exception class raised when the REST API returns an error.
   # The error code and message will be parsed out of the HTTP response,
   # which is also included in the response attribute.

--- a/lib/algolia/responses/add_api_key_response.rb
+++ b/lib/algolia/responses/add_api_key_response.rb
@@ -18,6 +18,9 @@ module Algolia
     def wait(opts = {})
       retries_count = 1
 
+      stop_after_seconds = @client.config.wait_task_timeout || opts[:wait_task_timeout]
+      start_time = Time.now.to_i
+
       until @done
         begin
           @client.get_api_key(@raw_response[:key], opts)
@@ -26,6 +29,12 @@ module Algolia
           if e.code != 404
             raise e
           end
+
+          unless stop_after_seconds.nil?
+            elapsed_seconds = Time.now.to_i - start_time
+            raise AlgoliaWaitTaskTimedOutError, "waiting for task timed out after #{stop_after_seconds} seconds" if elapsed_seconds >= stop_after_seconds
+          end
+
           retries_count    += 1
           time_before_retry = retries_count * Defaults::WAIT_TASK_DEFAULT_TIME_BEFORE_RETRY
           sleep(time_before_retry.to_f / 1000)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes-ish
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change
This PR proposes a way in which we can break out of loops when waiting for a task to finish. There are _some_ scenarios in which a task ID will never resolve, and so we'll infinitely wait for the task to be done. By adding a configurable timeout, we can abort waiting after _x_ seconds, and raise a specific timeout error so that the developer can handle the timeout as they see fit.