### PR TITLE
chore: move Helpers into Algolia namespace

### DIFF
--- a/lib/algolia/helpers.rb
+++ b/lib/algolia/helpers.rb
@@ -1,134 +1,136 @@
 require 'multi_json'
 
-module Helpers
-  # Convert an Hash to json
-  #
-  def to_json(body)
-    body.is_a?(String) ? body : MultiJson.dump(body)
-  end
-
-  # Converts each key of a hash to symbols
-  #
-  def symbolize_hash(hash)
-    hash.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
-  end
-
-  # Convert params to a full query string
-  #
-  def handle_params(params)
-    params.nil? || params.empty? ? '' : "?#{to_query_string(params)}"
-  end
-
-  # Create a query string from params
-  #
-  def to_query_string(params)
-    params.map do |key, value|
-      "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"
-    end.join('&')
-  end
-
-  # Convert a json object to an hash
-  #
-  def json_to_hash(json, symbolize_keys)
-    MultiJson.load(json, symbolize_keys: symbolize_keys)
-  end
-
-  # Retrieve the given value associated with a key, in string or symbol format
-  #
-  def get_option(hash, key)
-    hash[key.to_sym] || hash[key] || nil
-  end
-
-  # Build a path with the given arguments
-  #
-  def path_encode(path, *args)
-    arguments = []
-    args.each do |arg|
-      arguments.push(CGI.escape(CGI.unescape(arg.to_s)))
+module Algolia
+  module Helpers
+    # Convert an Hash to json
+    #
+    def to_json(body)
+      body.is_a?(String) ? body : MultiJson.dump(body)
     end
 
-    format(path, *arguments)
-  end
+    # Converts each key of a hash to symbols
+    #
+    def symbolize_hash(hash)
+      hash.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+    end
 
-  # Support to convert old settings to their new names
-  #
-  def deserialize_settings(data, symbolize_keys)
-    settings = data
-    keys     = {
-      attributesToIndex: 'searchableAttributes',
-      numericAttributesToIndex: 'numericAttributesForFiltering',
-      slaves: 'replicas'
-    }
+    # Convert params to a full query string
+    #
+    def handle_params(params)
+      params.nil? || params.empty? ? '' : "?#{to_query_string(params)}"
+    end
 
-    keys.each do |deprecated_key, current_key|
-      deprecated_key = symbolize_keys ? deprecated_key : deprecated_key.to_s
-      if settings.has_key?(deprecated_key)
-        key           = symbolize_keys ? current_key.to_sym : current_key.to_s
-        settings[key] = settings.delete(deprecated_key)
+    # Create a query string from params
+    #
+    def to_query_string(params)
+      params.map do |key, value|
+        "#{CGI.escape(key.to_s)}=#{CGI.escape(value.to_s)}"
+      end.join('&')
+    end
+
+    # Convert a json object to an hash
+    #
+    def json_to_hash(json, symbolize_keys)
+      MultiJson.load(json, symbolize_keys: symbolize_keys)
+    end
+
+    # Retrieve the given value associated with a key, in string or symbol format
+    #
+    def get_option(hash, key)
+      hash[key.to_sym] || hash[key] || nil
+    end
+
+    # Build a path with the given arguments
+    #
+    def path_encode(path, *args)
+      arguments = []
+      args.each do |arg|
+        arguments.push(CGI.escape(CGI.unescape(arg.to_s)))
+      end
+
+      format(path, *arguments)
+    end
+
+    # Support to convert old settings to their new names
+    #
+    def deserialize_settings(data, symbolize_keys)
+      settings = data
+      keys     = {
+        attributesToIndex: 'searchableAttributes',
+        numericAttributesToIndex: 'numericAttributesForFiltering',
+        slaves: 'replicas'
+      }
+
+      keys.each do |deprecated_key, current_key|
+        deprecated_key = symbolize_keys ? deprecated_key : deprecated_key.to_s
+        if settings.has_key?(deprecated_key)
+          key           = symbolize_keys ? current_key.to_sym : current_key.to_s
+          settings[key] = settings.delete(deprecated_key)
+        end
+      end
+
+      settings
+    end
+
+    def self.included(base)
+      base.extend(Helpers)
+    end
+
+    def hash_includes_subset?(hash, subset)
+      res = true
+      subset.each do |k, v|
+        res &&= hash[k] == v
+      end
+      res
+    end
+
+    # Check the passed object to determine if it's an array
+    #
+    # @param object [Object]
+    #
+    def check_array(object)
+      raise Algolia::AlgoliaError, 'argument must be an array of objects' unless object.is_a?(Array)
+    end
+
+    # Check the passed object
+    #
+    # @param object [Object]
+    # @param in_array [Boolean] whether the object is an array or not
+    #
+    def check_object(object, in_array = false)
+      case object
+      when Array
+        raise Algolia::AlgoliaError, in_array ? 'argument must be an array of objects' : 'argument must not be an array'
+      when String, Integer, Float, TrueClass, FalseClass, NilClass
+        raise Algolia::AlgoliaError, "argument must be an #{'array of' if in_array} object, got: #{object.inspect}"
       end
     end
 
-    settings
-  end
-
-  def self.included(base)
-    base.extend(Helpers)
-  end
-
-  def hash_includes_subset?(hash, subset)
-    res = true
-    subset.each do |k, v|
-      res &&= hash[k] == v
+    # Check if passed object has a objectID
+    #
+    # @param object [Object]
+    # @param object_id [String]
+    #
+    def get_object_id(object, object_id = nil)
+      check_object(object)
+      object_id ||= object[:objectID] || object['objectID']
+      raise Algolia::AlgoliaError, "Missing 'objectID'" if object_id.nil?
+      object_id
     end
-    res
-  end
 
-  # Check the passed object to determine if it's an array
-  #
-  # @param object [Object]
-  #
-  def check_array(object)
-    raise Algolia::AlgoliaError, 'argument must be an array of objects' unless object.is_a?(Array)
-  end
-
-  # Check the passed object
-  #
-  # @param object [Object]
-  # @param in_array [Boolean] whether the object is an array or not
-  #
-  def check_object(object, in_array = false)
-    case object
-    when Array
-      raise Algolia::AlgoliaError, in_array ? 'argument must be an array of objects' : 'argument must not be an array'
-    when String, Integer, Float, TrueClass, FalseClass, NilClass
-      raise Algolia::AlgoliaError, "argument must be an #{'array of' if in_array} object, got: #{object.inspect}"
-    end
-  end
-
-  # Check if passed object has a objectID
-  #
-  # @param object [Object]
-  # @param object_id [String]
-  #
-  def get_object_id(object, object_id = nil)
-    check_object(object)
-    object_id ||= object[:objectID] || object['objectID']
-    raise Algolia::AlgoliaError, "Missing 'objectID'" if object_id.nil?
-    object_id
-  end
-
-  # Build a batch request
-  #
-  # @param action [String] action to perform on the engine
-  # @param objects [Array] objects on which build the action
-  # @param with_object_id [Boolean] if set to true, check if each object has an objectID set
-  #
-  def chunk(action, objects, with_object_id = false)
-    objects.map do |object|
-      check_object(object, true)
-      request            = { action: action, body: object }
-      request[:objectID] = get_object_id(object).to_s if with_object_id
-      request
+    # Build a batch request
+    #
+    # @param action [String] action to perform on the engine
+    # @param objects [Array] objects on which build the action
+    # @param with_object_id [Boolean] if set to true, check if each object has an objectID set
+    #
+    def chunk(action, objects, with_object_id = false)
+      objects.map do |object|
+        check_object(object, true)
+        request            = { action: action, body: object }
+        request[:objectID] = get_object_id(object).to_s if with_object_id
+        request
+      end
     end
   end
 end

--- a/sig/helpers.rbs
+++ b/sig/helpers.rbs
@@ -1,12 +1,14 @@
-module Helpers
+module Algolia
+  module Helpers
 
-  def to_json: (String|Hash[Symbol, String] body) -> String
-  def symbolize_hash: (Hash[Symbol|String, untyped] hash) -> Hash[Symbol, untyped]
-  def handle_params: (Hash[Symbol, String] params) -> String
-  def to_query_string: (Hash[Symbol, String] params) -> String
-  def json_to_hash: (String json, bool symbolize_keys) -> Hash[Symbol, String]
-  def get_option: ([Symbol|String, String] hash, String key) -> (String | [String])
-  def path_encode: (String path, *String args) -> String
-  def deserialize_settings: (Hash[Symbol|String, String] data) -> Hash[Symbol, String]
-  def self.included: (self base) -> self
+    def to_json: (String|Hash[Symbol, String] body) -> String
+    def symbolize_hash: (Hash[Symbol|String, untyped] hash) -> Hash[Symbol, untyped]
+    def handle_params: (Hash[Symbol, String] params) -> String
+    def to_query_string: (Hash[Symbol, String] params) -> String
+    def json_to_hash: (String json, bool symbolize_keys) -> Hash[Symbol, String]
+    def get_option: ([Symbol|String, String] hash, String key) -> (String | [String])
+    def path_encode: (String path, *String args) -> String
+    def deserialize_settings: (Hash[Symbol|String, String] data) -> Hash[Symbol, String]
+    def self.included: (self base) -> self
+  end
 end

--- a/test/algolia/unit/helpers_test.rb
+++ b/test/algolia/unit/helpers_test.rb
@@ -2,7 +2,7 @@ require 'algolia'
 require 'test_helper'
 
 class HelpersTest
-  include Helpers
+  include Algolia::Helpers
 
   describe 'test helpers' do
     def test_deserialize_settings

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,7 @@ class Minitest::Test
   attr_reader :search_client
 
   include Minitest::Hooks
-  include Helpers
+  include Algolia::Helpers
   @@search_config = Algolia::Search::Config.new(application_id: APPLICATION_ID_1, api_key: ADMIN_KEY_1, user_agent: USER_AGENT)
   @@search_client = Algolia::Search::Client.new(@@search_config)
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | yes
| Related Issue     | Fix #488
| Need Doc update   | no


## Describe your change
This moves our `Helpers` module out of the global namespace to prevent possible collisions with other packages or applications. This is technically a BC-breaking change, since some users may rely on this class outside of the code we maintain. This means we likely can't release this until the next major release.