### PR TITLE
Fix issue with timeout's not being passed to the http_request

### DIFF
--- a/lib/algolia/transport/transport.rb
+++ b/lib/algolia/transport/transport.rb
@@ -96,6 +96,8 @@ module Algolia
         request[:path]    = build_uri_path(path, request_options.params)
         request[:body]    = build_body(body, request_options, method)
         request[:headers] = generate_headers(request_options)
+        request[:timeout] = request_options.timeout
+        request[:connect_timeout] = request_options.connect_timeout
         request
       end
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    
| BC breaks?        | no     
| Related Issue     |  https://github.com/algolia/algoliasearch-client-ruby/issues/494
| Need Doc update   | no


## Describe your change
Adds the timeout to the request object so we can pass it to the `http_requester`

We can see from here our intention is to end up with the `timeout` and `connect_timeout` keys present in the request object that is later passed to `send_request`

https://github.com/algolia/algoliasearch-client-ruby/blob/c8c8c6b79d34e4788daeb04e1003695c010c87d6/lib/algolia/transport/transport.rb#L51-L69

But in fact we are not actually adding those keys in the `build_request` method

https://github.com/algolia/algoliasearch-client-ruby/blob/c8c8c6b79d34e4788daeb04e1003695c010c87d6/lib/algolia/transport/transport.rb#L93-L100

## What problem is this fixing?
We were trying to send over a request timeout to the client but noticed it wasn't being respected when Algolia intermittently was taking too long to respond