### PR TITLE
fix(http_requester): use host url as connections cache key

### DIFF
--- a/lib/algolia/http/http_requester.rb
+++ b/lib/algolia/http/http_requester.rb
@@ -65,7 +65,7 @@ module Algolia
       # @return [Faraday::Connection]
       #
       def connection(host)
-        @connections[host.accept] ||= Faraday.new(build_url(host)) do |f|
+        @connections[host.url] ||= Faraday.new(build_url(host)) do |f|
           f.adapter @adapter.to_sym
         end
       end

--- a/test/algolia/unit/http_requester_test.rb
+++ b/test/algolia/unit/http_requester_test.rb
@@ -1,0 +1,27 @@
+require 'algolia'
+require 'test_helper'
+
+class HttpRequesterTest
+  describe 'connection' do
+    def test_caches_http_client_connections
+      requester = Algolia::Http::HttpRequester.new(Defaults::ADAPTER, nil)
+      host1     = Algolia::Transport::StatefulHost.new('host1')
+
+      # rubocop:disable Lint/UselessComparison
+      assert requester.connection(host1) == requester.connection(host1)
+      # rubocop:enable Lint/UselessComparison
+      assert_equal requester.connection(host1).url_prefix.host, 'host1'
+    end
+
+    def test_caches_hosts_independent_of_each_other
+      requester = Algolia::Http::HttpRequester.new(Defaults::ADAPTER, nil)
+      host1     = Algolia::Transport::StatefulHost.new('host1')
+      host2     = Algolia::Transport::StatefulHost.new('host2')
+
+      assert requester.connection(host1) != requester.connection(host2)
+
+      assert_equal requester.connection(host1).url_prefix.host, 'host1'
+      assert_equal requester.connection(host2).url_prefix.host, 'host2'
+    end
+  end
+end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | ?     
| Related Issue     | N/A
| Need Doc update   | no


## Describe your change

Use the `host.url`, which should be unique, instead of the `host.accept` value, which in most cases is not unique, when caching the http client in the `@connections` instance variable of `http_requester`

## What problem is this fixing?

Failing to do that, all hosts will actually use the same http client as the first one (assuming they share the same `accept` value). This prevents the retry strategy from working properly
For example:
1. you have `host1`, `host2` & `host3` configured. `host1` is down.
2. you call `algolia_client.indexes`
3. `transporter` -> `retry_strategy` -> `http_requester` will try to request host1 and instantiate an http client with its url.
4. The request fails
5. There's a retry on host2, but `http_requester.connections[host2.accept]` will yield the same http client as `host1`!
6. All subsequent requests will fail despite the retry strategy
