### PR TITLE
fix(helpers): encode index_name properly

### DIFF
--- a/lib/algolia/helpers.rb
+++ b/lib/algolia/helpers.rb
@@ -44,7 +44,7 @@ module Helpers
   def path_encode(path, *args)
     arguments = []
     args.each do |arg|
-      arguments.push(CGI.escape(CGI.unescape(arg.to_s)))
+      arguments.push(CGI.escape(arg.to_s))
     end
 
     format(path, *arguments)

--- a/test/algolia/unit/helpers_test.rb
+++ b/test/algolia/unit/helpers_test.rb
@@ -40,6 +40,10 @@ class HelpersTest
       deserialized_settings = deserialize_settings(old_settings, false)
       assert_equal new_settings, deserialized_settings
     end
+
+    def test_path_encode
+      assert_equal path_encode('/1/indexes/%s/settings', 'premium+ some_name'), '/1/indexes/premium%2B+some_name/settings'
+    end
   end
 
   describe 'test hash_includes_subset' do


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no 
| BC breaks?        | Technically yes     
| Related Issue     | Reported internally
| Need Doc update   | no


## Describe your change

Change how the index name is encoded in the url by not using `CGI.unescape` first.

## What problem is this fixing?

Currently, the client doesn't handle index names with `+` signs in their names for example

```rb
# Given the following index name
index_name = 'foo+ bar'
# Notice the + sign being turned into a space
CGI.unescape(index_name) == 'foo  bar'
# Now everything is turned into a +, which would be interpreted as spaces
CGI.escape(CGI.unescape('foo+ bar')) == 'foo++bar'
```

While the behaviour is more correct and matches what is done in [the js client](https://github.com/algolia/algoliasearch-client-javascript/blob/db9953ce626dc734f8e7eaf88b78d9c9c0bb5a54/packages/client-common/src/helpers.ts#L42-L47) for example, it could break code that relied on the faulty behaviour.
