### PR TITLE
Chore/update support email

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -148,7 +148,7 @@ To run only the integration tests:
 bundle exec rake test:integration
 ```
 
-We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to the Algolia Support Team: https://alg.li/support.
+We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to the [Algolia Support Team](https://alg.li/support).
 
 ## Linting
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -148,7 +148,7 @@ To run only the integration tests:
 bundle exec rake test:integration
 ```
 
-We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to the Algolia Support team: https://alg.li/support.
+We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to the Algolia Support Team: https://alg.li/support.
 
 ## Linting
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -148,7 +148,7 @@ To run only the integration tests:
 bundle exec rake test:integration
 ```
 
-We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to [our support team](support@algolia.com).
+We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to the Algolia Support team: https://alg.li/support.
 
 ## Linting
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no 
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Hey team!
The Support team is currently in a process of removing support@algolia.com email from all GitHub repos and updating it to link to the new ticket form. We kindly ask that you review the changes made removing references to support@algolia.com
Thanks!