### PR TITLE
Fix get_objects fails with attributesToRetrieve

### DIFF
--- a/lib/algolia/search_index.rb
+++ b/lib/algolia/search_index.rb
@@ -199,7 +199,7 @@ module Algolia
       def get_objects(object_ids, opts = {})
         request_options        = symbolize_hash(opts)
         attributes_to_retrieve = get_option(request_options, 'attributesToRetrieve')
-        request_options.delete(:attributesToRetrieve)
+        opts.delete(:attributesToRetrieve)
 
         requests = []
         object_ids.each do |object_id|


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no     
| Related Issue     | Fix https://github.com/algolia/algoliasearch-client-ruby/issues/469
| Need Doc update   | no


## Describe your change

Fix the incorrect `opts` passed to **get_objects**

## What problem is this fixing?

When passing opts: `attributesToRetrieve` to get_objects we receive an excpetion that `attributesToRetrieve` is an invalid key. `attributesToRetrieve` is supported in `request_options`, not in `opts`.

Here is the proof:
```ruby
[1] pry(#<Algolia::Search::Index>)> opts
=> {:attributesToRetrieve=>"id"}

[2] pry(#<Algolia::Search::Index>)> @transporter.read(:POST, '/1/indexes/*/objects', { 'requests': requests }, opts)
Algolia::AlgoliaHttpError: invalid key 'attributesToRetrieve'. Expected: appID, apiKey, requests, allowNestedFacets (near 1:112)
from /Users/camel/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/algolia-2.3.4/lib/algolia/transport/transport.rb:74:in `block in request'

[3] pry(#<Algolia::Search::Index>)> @transporter.read(:POST, '/1/indexes/*/objects', { 'requests': requests }, {})
=> {:results=>[{:id=>1, :objectID=>"1"}]}

```
