### PR TITLE
Chore/update support email

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -148,7 +148,7 @@ To run only the integration tests:
 bundle exec rake test:integration
 ```
 
-We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to the Algolia Support Team: https://alg.li/support.
+We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to the [Algolia Support Team](https://alg.li/support).
 
 ## Linting
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -148,7 +148,7 @@ To run only the integration tests:
 bundle exec rake test:integration
 ```
 
-We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to the Algolia Support team: https://alg.li/support.
+We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to the Algolia Support Team: https://alg.li/support.
 
 ## Linting
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -148,7 +148,7 @@ To run only the integration tests:
 bundle exec rake test:integration
 ```
 
-We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to [our support team](support@algolia.com).
+We ask that for each fix or feature submitted, you add at least one test demonstrating its behaviour. As you will need to use your own Algolia credentials to run them, we advise you to keep them short and use a small dataset, as well as using a mock requester anytime it's possible. If you encounter huge data overload because of testing, please reach out to the Algolia Support team: https://alg.li/support.
 
 ## Linting
 

--- a/algolia.gemspec
+++ b/algolia.gemspec
@@ -8,8 +8,6 @@ Gem::Specification.new do |spec|
   spec.name          = 'algolia'
   spec.version       = Algolia::VERSION
   spec.authors       = ['Algolia']
-  spec.email         = ['support@algolia.com']
-
   spec.date        = Date.today
   spec.licenses    = ['MIT']
   spec.summary     = 'A simple Ruby client for the algolia.com REST API'


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Hey team!
The Support team is currently in a process of removing [support@algolia.com](mailto:support@algolia.com) email from all GitHub repos. We kindly ask that you review the changes made removing references to [support@algolia.com](mailto:support@algolia.com)

Removed the spec.email line following advice given here: https://algolia.slack.com/archives/C5593MY56/p1719325319640729

Thanks!

