### PR TITLE
Fix Defaults reference in Algolia::Transport::RetryStrategy

### DIFF
--- a/lib/algolia.rb
+++ b/lib/algolia.rb
@@ -5,6 +5,7 @@
 # Common files
 require "algolia/api_client"
 require "algolia/api_error"
+require "algolia/defaults"
 require "algolia/error"
 require "algolia/version"
 require "algolia/configuration"

--- a/lib/algolia/defaults.rb
+++ b/lib/algolia/defaults.rb
@@ -1,0 +1,5 @@
+module Algolia
+  module Defaults
+    TTL = 300
+  end
+end


### PR DESCRIPTION
It looks like the Algolia::Transport::RetryStrategy still [references](https://github.com/algolia/algoliasearch-client-ruby/blob/main/lib/algolia/transport/retry_strategy.rb#L89) the [Defaults](https://github.com/algolia/algoliasearch-client-ruby/blob/2.3.4/lib/algolia/defaults.rb) module, which was removed sometime between version 2 and now. This fixes the broken reference.