### PR TITLE
fix(client): fix empty check for integer timeouts

### DIFF
--- a/lib/algolia/api/abtesting_client.rb
+++ b/lib/algolia/api/abtesting_client.rb
@@ -38,15 +38,15 @@ module Algolia
     end
 
     def self.create_with_config(config)
-      if config.connect_timeout.nil? || config.connect_timeout.empty?
+      if config.connect_timeout.nil?
         config.connect_timeout = 2000
       end
 
-      if config.read_timeout.nil? || config.read_timeout.empty?
+      if config.read_timeout.nil?
         config.read_timeout = 5000
       end
 
-      if config.write_timeout.nil? || config.write_timeout.empty?
+      if config.write_timeout.nil?
         config.write_timeout = 30000
       end
 

--- a/lib/algolia/api/analytics_client.rb
+++ b/lib/algolia/api/analytics_client.rb
@@ -38,15 +38,15 @@ module Algolia
     end
 
     def self.create_with_config(config)
-      if config.connect_timeout.nil? || config.connect_timeout.empty?
+      if config.connect_timeout.nil?
         config.connect_timeout = 2000
       end
 
-      if config.read_timeout.nil? || config.read_timeout.empty?
+      if config.read_timeout.nil?
         config.read_timeout = 5000
       end
 
-      if config.write_timeout.nil? || config.write_timeout.empty?
+      if config.write_timeout.nil?
         config.write_timeout = 30000
       end
 

--- a/lib/algolia/api/composition_client.rb
+++ b/lib/algolia/api/composition_client.rb
@@ -31,15 +31,15 @@ module Algolia
     end
 
     def self.create_with_config(config)
-      if config.connect_timeout.nil? || config.connect_timeout.empty?
+      if config.connect_timeout.nil?
         config.connect_timeout = 2000
       end
 
-      if config.read_timeout.nil? || config.read_timeout.empty?
+      if config.read_timeout.nil?
         config.read_timeout = 5000
       end
 
-      if config.write_timeout.nil? || config.write_timeout.empty?
+      if config.write_timeout.nil?
         config.write_timeout = 30000
       end
 

--- a/lib/algolia/api/ingestion_client.rb
+++ b/lib/algolia/api/ingestion_client.rb
@@ -38,15 +38,15 @@ module Algolia
     end
 
     def self.create_with_config(config)
-      if config.connect_timeout.nil? || config.connect_timeout.empty?
+      if config.connect_timeout.nil?
         config.connect_timeout = 25000
       end
 
-      if config.read_timeout.nil? || config.read_timeout.empty?
+      if config.read_timeout.nil?
         config.read_timeout = 25000
       end
 
-      if config.write_timeout.nil? || config.write_timeout.empty?
+      if config.write_timeout.nil?
         config.write_timeout = 25000
       end
 

--- a/lib/algolia/api/insights_client.rb
+++ b/lib/algolia/api/insights_client.rb
@@ -38,15 +38,15 @@ module Algolia
     end
 
     def self.create_with_config(config)
-      if config.connect_timeout.nil? || config.connect_timeout.empty?
+      if config.connect_timeout.nil?
         config.connect_timeout = 2000
       end
 
-      if config.read_timeout.nil? || config.read_timeout.empty?
+      if config.read_timeout.nil?
         config.read_timeout = 5000
       end
 
-      if config.write_timeout.nil? || config.write_timeout.empty?
+      if config.write_timeout.nil?
         config.write_timeout = 30000
       end
 

--- a/lib/algolia/api/monitoring_client.rb
+++ b/lib/algolia/api/monitoring_client.rb
@@ -23,15 +23,15 @@ module Algolia
     end
 
     def self.create_with_config(config)
-      if config.connect_timeout.nil? || config.connect_timeout.empty?
+      if config.connect_timeout.nil?
         config.connect_timeout = 2000
       end
 
-      if config.read_timeout.nil? || config.read_timeout.empty?
+      if config.read_timeout.nil?
         config.read_timeout = 5000
       end
 
-      if config.write_timeout.nil? || config.write_timeout.empty?
+      if config.write_timeout.nil?
         config.write_timeout = 30000
       end
 

--- a/lib/algolia/api/personalization_client.rb
+++ b/lib/algolia/api/personalization_client.rb
@@ -38,15 +38,15 @@ module Algolia
     end
 
     def self.create_with_config(config)
-      if config.connect_timeout.nil? || config.connect_timeout.empty?
+      if config.connect_timeout.nil?
         config.connect_timeout = 2000
       end
 
-      if config.read_timeout.nil? || config.read_timeout.empty?
+      if config.read_timeout.nil?
         config.read_timeout = 5000
       end
 
-      if config.write_timeout.nil? || config.write_timeout.empty?
+      if config.write_timeout.nil?
         config.write_timeout = 30000
       end
 

--- a/lib/algolia/api/query_suggestions_client.rb
+++ b/lib/algolia/api/query_suggestions_client.rb
@@ -38,15 +38,15 @@ module Algolia
     end
 
     def self.create_with_config(config)
-      if config.connect_timeout.nil? || config.connect_timeout.empty?
+      if config.connect_timeout.nil?
         config.connect_timeout = 2000
       end
 
-      if config.read_timeout.nil? || config.read_timeout.empty?
+      if config.read_timeout.nil?
         config.read_timeout = 5000
       end
 
-      if config.write_timeout.nil? || config.write_timeout.empty?
+      if config.write_timeout.nil?
         config.write_timeout = 30000
       end
 

--- a/lib/algolia/api/recommend_client.rb
+++ b/lib/algolia/api/recommend_client.rb
@@ -31,15 +31,15 @@ module Algolia
     end
 
     def self.create_with_config(config)
-      if config.connect_timeout.nil? || config.connect_timeout.empty?
+      if config.connect_timeout.nil?
         config.connect_timeout = 2000
       end
 
-      if config.read_timeout.nil? || config.read_timeout.empty?
+      if config.read_timeout.nil?
         config.read_timeout = 5000
       end
 
-      if config.write_timeout.nil? || config.write_timeout.empty?
+      if config.write_timeout.nil?
         config.write_timeout = 30000
       end
 

--- a/lib/algolia/api/search_client.rb
+++ b/lib/algolia/api/search_client.rb
@@ -34,15 +34,15 @@ module Algolia
     end
 
     def self.create_with_config(config)
-      if config.connect_timeout.nil? || config.connect_timeout.empty?
+      if config.connect_timeout.nil?
         config.connect_timeout = 2000
       end
 
-      if config.read_timeout.nil? || config.read_timeout.empty?
+      if config.read_timeout.nil?
         config.read_timeout = 5000
       end
 
-      if config.write_timeout.nil? || config.write_timeout.empty?
+      if config.write_timeout.nil?
         config.write_timeout = 30000
       end
 


### PR DESCRIPTION
Maybe I'm missing something but after upgrading to the latest version of the gem my timeout settings started breaking: 

```ruby
::Algolia::SearchClient.create(
    app_id,
    api_key,
    {
      connect_timeout: 5_000
    }
  )
```

The error seemed to be caused by the new `empty?` checks that were added previous to the client initialization. Why are we now checking for both nil? and empty? is the idea to use strings now? that doesn't seem to be the case since the default seem to be numbers. So let me know if this was an error or maybe we need to update the documentation on how to set up timeouts.


Thanks!